### PR TITLE
Implement PDF BOM extraction service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Stücklisten-Extractor
+
+Diese Anwendung extrahiert aus technischen Zeichnungen im PDF-Format automatisch Stücklisten (Bill of Materials).
+Sie besteht aus einer wiederverwendbaren Python-Bibliothek und einem kleinen FastAPI-Dienst, über den sich die
+Extraktion als Webservice aufrufen lässt.
+
+## Funktionen
+
+- Erkennung gängiger Stücklisten-Tabellen mit deutsch- und englischsprachigen Spaltenüberschriften.
+- Automatische Interpretation wichtiger Spalten wie Position, Artikelnummer, Beschreibung, Menge, Einheit und Material.
+- Robuste PDF-Auswertung auf Basis von [pdfplumber](https://github.com/jsvine/pdfplumber).
+- REST-Schnittstelle (FastAPI) zur Integration in bestehende Systeme.
+- Umfangreiche Tests inklusive Erzeugung von Beispiel-PDFs.
+
+## Installation
+
+1. Optional ein virtuelles Python-Umfeld anlegen:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Abhängigkeiten installieren:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Verwendung der Bibliothek
+
+```python
+from bom_extractor import extract_bom_from_pdf
+
+result = extract_bom_from_pdf("/pfad/zur/zeichnung.pdf")
+for item in result.items:
+    print(item.to_dict())
+```
+
+Die Funktion gibt ein `BOMExtractionResult`-Objekt zurück, welches die erkannten Einträge, die gefundenen Spalten sowie
+Metadaten wie die ausgewerteten Seiten enthält.
+
+## Start des Webservices
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Anschließend steht unter `http://127.0.0.1:8000/docs` eine interaktive Dokumentation zur Verfügung. Über den Endpunkt
+`POST /extract` kann eine PDF-Datei hochgeladen werden. Die Antwort enthält die extrahierte Stückliste sowie Metadaten
+zur Verarbeitung.
+
+## Tests
+
+```bash
+pytest
+```
+
+Die Tests erzeugen automatisch Beispiel-PDFs und verifizieren die Extraktionslogik sowie den API-Endpunkt.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi>=0.103,<0.104
+uvicorn[standard]>=0.23,<0.24
+pdfplumber>=0.10,<0.11
+python-multipart>=0.0.6,<0.0.7
+pydantic>=1.10,<2.0
+reportlab>=3.6,<3.7
+pytest>=7.4,<8.0
+httpx>=0.24,<0.25

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application exposing the BOM extraction service."""

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,59 @@
+"""FastAPI entry point for the Stücklisten-Extraktionsdienst."""
+from __future__ import annotations
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+
+from bom_extractor import BOMExtractionError, extract_bom_from_bytes
+from .schemas import BOMResponseModel
+
+app = FastAPI(
+    title="BOM Extractor",
+    description=(
+        "Extrahiert Stücklisten aus technischen Zeichnungen im PDF-Format. "
+        "Die API akzeptiert PDF-Dateien als Multipart-Uploads und liefert eine strukturierte Stückliste zurück."
+    ),
+    version="1.0.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/")
+def index() -> dict:
+    """Simple health endpoint that documents the service."""
+
+    return {
+        "status": "ok",
+        "message": "Nutzen Sie POST /extract, um eine Stückliste aus einer PDF zu extrahieren.",
+    }
+
+
+@app.post("/extract", response_model=BOMResponseModel)
+async def extract_bom(file: UploadFile = File(...)) -> BOMResponseModel:
+    """Extract a bill of materials from an uploaded PDF drawing."""
+
+    if not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Bitte laden Sie eine PDF-Datei hoch.")
+
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=400, detail="Die übermittelte Datei ist leer.")
+
+    try:
+        result = extract_bom_from_bytes(content, source=file.filename)
+    except BOMExtractionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=500, detail="Fehler beim Lesen der PDF-Datei.") from exc
+
+    return BOMResponseModel(**result.to_dict())
+
+
+__all__ = ["app"]

--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -1,0 +1,26 @@
+"""Pydantic schemas for the API layer."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+class BOMItemModel(BaseModel):
+    position: Optional[str] = None
+    part_number: Optional[str] = None
+    description: Optional[str] = None
+    quantity: Optional[Union[int, float]] = None
+    unit: Optional[str] = None
+    material: Optional[str] = None
+    comment: Optional[str] = None
+    extras: Dict[str, str] = Field(default_factory=dict)
+
+
+class BOMResponseModel(BaseModel):
+    items: List[BOMItemModel]
+    detected_columns: List[str]
+    metadata: Dict[str, Union[str, List[int], int]]
+
+
+__all__ = ["BOMItemModel", "BOMResponseModel"]

--- a/src/bom_extractor/__init__.py
+++ b/src/bom_extractor/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities for extracting bills of materials (Stücklisten) from PDF drawings."""
+
+from .extractor import (
+    BOMExtractionError,
+    BOMExtractionResult,
+    BOMItem,
+    extract_bom_from_bytes,
+    extract_bom_from_pdf,
+)
+
+__all__ = [
+    "BOMItem",
+    "BOMExtractionResult",
+    "BOMExtractionError",
+    "extract_bom_from_pdf",
+    "extract_bom_from_bytes",
+]

--- a/src/bom_extractor/extractor.py
+++ b/src/bom_extractor/extractor.py
@@ -1,0 +1,383 @@
+"""Core logic for extracting bills of materials from PDF engineering drawings."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import io
+import re
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import pdfplumber
+
+__all__ = [
+    "BOMItem",
+    "BOMExtractionResult",
+    "BOMExtractionError",
+    "extract_bom_from_pdf",
+    "extract_bom_from_bytes",
+]
+
+
+TABLE_SETTINGS: Sequence[Dict[str, Union[str, float]]] = (
+    {"vertical_strategy": "lines", "horizontal_strategy": "lines"},
+    {"vertical_strategy": "text", "horizontal_strategy": "text"},
+    {"vertical_strategy": "lines", "horizontal_strategy": "text"},
+)
+
+
+HEADER_ALIASES: Dict[str, Tuple[str, ...]] = {
+    "position": (
+        "position",
+        "pos",
+        "pos.",
+        "item",
+        "itemno",
+        "item no",
+        "item no.",
+        "no",
+        "nr",
+        "index",
+    ),
+    "part_number": (
+        "part",
+        "partno",
+        "part no",
+        "part-number",
+        "article",
+        "artikel",
+        "artnr",
+        "art.nr",
+        "drawing",
+        "drawing no",
+        "zeichnungs",
+        "zeichnungsnr",
+        "zeichnung",
+        "bestell",
+        "order",
+        "item code",
+        "teilenummer",
+    ),
+    "description": (
+        "description",
+        "descr",
+        "desc",
+        "bezeichnung",
+        "benennung",
+        "designation",
+        "title",
+        "titel",
+        "beschreibung",
+    ),
+    "quantity": (
+        "qty",
+        "qty.",
+        "quantity",
+        "menge",
+        "anzahl",
+        "stück",
+        "stückzahl",
+        "stk",
+        "st",
+        "pcs",
+        "qty/qty",
+    ),
+    "unit": (
+        "unit",
+        "einheit",
+        "uom",
+        "ein",
+        "maßeinheit",
+    ),
+    "material": (
+        "material",
+        "werkstoff",
+        "mat",
+    ),
+    "comment": (
+        "comment",
+        "comments",
+        "bemerkung",
+        "bemerkungen",
+        "note",
+        "notes",
+        "remark",
+        "remarks",
+    ),
+}
+
+# Regular expression used to detect numbers (supporting comma as decimal separator)
+QUANTITY_RE = re.compile(
+    r"(?P<value>-?\d+(?:[\.,]\d+)?)\s*(?P<unit>[a-zA-Z%\u00b0\/]*)"
+)
+
+
+class BOMExtractionError(RuntimeError):
+    """Raised when the extractor cannot locate a valid bill of materials table."""
+
+
+@dataclass
+class BOMItem:
+    """Container for a single bill of materials entry."""
+
+    position: Optional[str] = None
+    part_number: Optional[str] = None
+    description: Optional[str] = None
+    quantity: Optional[Union[int, float]] = None
+    unit: Optional[str] = None
+    material: Optional[str] = None
+    comment: Optional[str] = None
+    extras: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Union[str, int, float, Dict[str, str], None]]:
+        """Convert the item into a serialisable dictionary."""
+
+        data = {
+            "position": self.position,
+            "part_number": self.part_number,
+            "description": self.description,
+            "quantity": self.quantity,
+            "unit": self.unit,
+            "material": self.material,
+            "comment": self.comment,
+            "extras": {k: v for k, v in self.extras.items() if v},
+        }
+        return {k: v for k, v in data.items() if v is not None and (v != {} or k == "extras")}
+
+
+@dataclass
+class BOMExtractionResult:
+    """Represents a complete bill of materials extracted from a drawing."""
+
+    items: List[BOMItem]
+    detected_columns: List[str]
+    metadata: Dict[str, Union[str, List[int], int]] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "items": [item.to_dict() for item in self.items],
+            "detected_columns": self.detected_columns,
+            "metadata": self.metadata,
+        }
+
+
+def extract_bom_from_pdf(path: Union[str, io.BytesIO]) -> BOMExtractionResult:
+    """Extract a bill of materials from a PDF file located at *path*."""
+
+    with pdfplumber.open(path) as pdf:
+        return _extract_from_pdf_document(pdf, source=getattr(path, "name", str(path)))
+
+
+def extract_bom_from_bytes(content: bytes, source: Optional[str] = None) -> BOMExtractionResult:
+    """Extract a bill of materials from in-memory PDF data."""
+
+    buffer = io.BytesIO(content)
+    buffer.name = source or "<memory>"
+    with pdfplumber.open(buffer) as pdf:
+        return _extract_from_pdf_document(pdf, source=buffer.name)
+
+
+def _extract_from_pdf_document(pdf: pdfplumber.PDF, source: Optional[str]) -> BOMExtractionResult:
+    items: List[BOMItem] = []
+    detected_columns: List[str] = []
+    pages_used: List[int] = []
+    tables_seen = 0
+
+    for page_index, page in enumerate(pdf.pages, start=1):
+        for table in _iter_tables(page):
+            tables_seen += 1
+            table_items, columns = _process_table(table)
+            if table_items:
+                items.extend(table_items)
+                detected_columns.extend(col for col in columns if col not in detected_columns)
+                pages_used.append(page_index)
+
+    if not items:
+        raise BOMExtractionError(
+            "Keine Stückliste in der PDF gefunden. Bitte stellen Sie sicher, dass die Zeichnung eine tabellarische "
+            "Stückliste mit Spaltenüberschriften enthält."
+        )
+
+    metadata: Dict[str, Union[str, List[int], int]] = {
+        "source": source or "<unknown>",
+        "pages": sorted(set(pages_used)),
+        "tables_checked": tables_seen,
+    }
+
+    return BOMExtractionResult(items=items, detected_columns=detected_columns, metadata=metadata)
+
+
+def _iter_tables(page: pdfplumber.page.Page) -> Iterable[List[List[Optional[str]]]]:
+    """Yield tables extracted from a PDF page using different detection strategies."""
+
+    yielded: List[List[List[Optional[str]]]] = []
+    for settings in TABLE_SETTINGS:
+        try:
+            tables = page.extract_tables(table_settings=settings)
+        except NotImplementedError:
+            continue
+        if not tables:
+            continue
+        for table in tables:
+            # Avoid returning duplicate tables produced by different strategies.
+            if table not in yielded:
+                yielded.append(table)
+                yield table
+
+
+def _process_table(raw_table: Sequence[Sequence[Optional[str]]]) -> Tuple[List[BOMItem], List[str]]:
+    """Attempt to interpret a raw table as a bill of materials."""
+
+    cleaned_table = [_clean_row(row) for row in raw_table if any(_cell_has_content(cell) for cell in row)]
+    if not cleaned_table:
+        return [], []
+
+    header_index, header_map, header_names = _find_header_row(cleaned_table)
+    if header_index is None:
+        return [], []
+
+    data_rows = cleaned_table[header_index + 1 :]
+    if not data_rows:
+        return [], []
+
+    items: List[BOMItem] = []
+    for row in data_rows:
+        item = _row_to_item(row, header_map, header_names)
+        if item:
+            items.append(item)
+
+    normalized_columns = sorted(set(header_map.values()))
+    return items, normalized_columns
+
+
+def _clean_row(row: Sequence[Optional[str]]) -> List[str]:
+    return [_normalise_cell(cell) for cell in row]
+
+
+def _normalise_cell(cell: Optional[str]) -> str:
+    if cell is None:
+        return ""
+    text = str(cell)
+    text = text.replace("\n", " ")
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _cell_has_content(cell: Optional[str]) -> bool:
+    return bool(_normalise_cell(cell))
+
+
+def _find_header_row(table: Sequence[Sequence[str]]) -> Tuple[Optional[int], Dict[int, str], Dict[int, str]]:
+    """Locate the header row within a table and return column mappings."""
+
+    best_index: Optional[int] = None
+    best_map: Dict[int, str] = {}
+    best_header_names: Dict[int, str] = {}
+    best_score = 0
+
+    for idx, row in enumerate(table):
+        mapping: Dict[int, str] = {}
+        names: Dict[int, str] = {}
+        score = 0
+
+        for col_index, cell in enumerate(row):
+            if not cell:
+                continue
+            normalised = _normalise_header(cell)
+            if not normalised:
+                continue
+            match = _match_header(normalised)
+            names[col_index] = normalised
+            if match and match not in mapping.values():
+                mapping[col_index] = match
+                score += 1
+
+        # Require at least two recognised columns for a confident BOM header.
+        if score >= 2 and score > best_score:
+            best_index = idx
+            best_map = mapping
+            best_header_names = names
+            best_score = score
+
+    return best_index, best_map, best_header_names
+
+
+def _normalise_header(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _match_header(value: str) -> Optional[str]:
+    for canonical, aliases in HEADER_ALIASES.items():
+        if value in aliases:
+            return canonical
+    return None
+
+
+def _row_to_item(row: Sequence[str], header_map: Dict[int, str], header_names: Dict[int, str]) -> Optional[BOMItem]:
+    recognised: Dict[str, str] = {}
+    extras: Dict[str, str] = {}
+
+    for idx, cell in enumerate(row):
+        if not cell:
+            continue
+        if idx in header_map:
+            recognised[header_map[idx]] = cell
+        else:
+            header_name = header_names.get(idx, f"column_{idx}")
+            extras[header_name] = cell
+
+    if not recognised and not extras:
+        return None
+
+    quantity_value: Optional[Union[int, float]] = None
+    unit_value: Optional[str] = None
+    if "quantity" in recognised:
+        quantity_value, unit_value = _parse_quantity(recognised.get("quantity"))
+
+    # If the unit column exists separately, it has precedence
+    if "unit" in recognised and recognised["unit"]:
+        unit_value = recognised["unit"]
+
+    item = BOMItem(
+        position=recognised.get("position"),
+        part_number=recognised.get("part_number"),
+        description=recognised.get("description"),
+        quantity=quantity_value,
+        unit=unit_value,
+        material=recognised.get("material"),
+        comment=recognised.get("comment"),
+        extras=extras,
+    )
+
+    # If a recognised field still contains data that should be treated as extra (e.g. quantity without value)
+    # we keep the original text in extras for traceability.
+    for key, value in recognised.items():
+        if key not in {"position", "part_number", "description", "quantity", "unit", "material", "comment"}:
+            item.extras[key] = value
+
+    # If we failed to parse a numeric quantity keep the raw text inside extras.
+    if "quantity" in recognised and quantity_value is None:
+        item.extras.setdefault("quantity_raw", recognised["quantity"])
+
+    return item
+
+
+def _parse_quantity(value: Optional[str]) -> Tuple[Optional[Union[int, float]], Optional[str]]:
+    if not value:
+        return None, None
+
+    match = QUANTITY_RE.search(value)
+    if not match:
+        return None, None
+
+    raw_value = match.group("value").replace(",", ".")
+    try:
+        numeric = float(raw_value)
+    except ValueError:
+        return None, match.group("unit") or None
+
+    if numeric.is_integer():
+        numeric_value: Union[int, float] = int(numeric)
+    else:
+        numeric_value = numeric
+
+    unit = match.group("unit") or None
+    return numeric_value, unit

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from .utils import build_pdf_table
+
+
+client = TestClient(app)
+
+
+def test_extract_endpoint(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "bom.pdf"
+    data = [
+        ["Item", "Qty", "Description"],
+        ["1", "5", "Washer"],
+        ["2", "3", "Screw"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    with pdf_path.open("rb") as pdf_file:
+        response = client.post(
+            "/extract", files={"file": (pdf_path.name, pdf_file, "application/pdf")}
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"][0]["description"] == "Washer"
+    assert payload["items"][0]["quantity"] == 5
+    assert payload["metadata"]["source"] == "bom.pdf"

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bom_extractor import BOMExtractionError, extract_bom_from_pdf
+from .utils import build_pdf_table, build_pdf_text
+
+
+def test_extract_basic_table(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "drawing.pdf"
+    data = [
+        ["Item", "Qty", "Description", "Material"],
+        ["1", "4", "Bolt M8", "Steel"],
+        ["2", "2", "Nut M8", "Steel"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    result = extract_bom_from_pdf(str(pdf_path))
+
+    assert result.detected_columns == ["description", "material", "position", "quantity"]
+    assert len(result.items) == 2
+    first = result.items[0]
+    assert first.position == "1"
+    assert first.description == "Bolt M8"
+    assert first.material == "Steel"
+    assert first.quantity == 4
+
+
+def test_extract_german_headers(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "zeichnung.pdf"
+    data = [
+        ["Pos.", "Benennung", "Menge", "Einheit"],
+        ["10", "Schraube M10", "12 Stk", "Stk"],
+        ["20", "Mutter M10", "8", "Stk"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    result = extract_bom_from_pdf(str(pdf_path))
+
+    assert len(result.items) == 2
+    first = result.items[0]
+    assert first.position == "10"
+    assert first.quantity == 12
+    assert first.unit == "Stk"
+
+
+def test_extract_raises_when_no_table(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "text.pdf"
+    build_pdf_text(pdf_path, ["Dies ist nur eine Beschreibung ohne Tabelle."])
+
+    with pytest.raises(BOMExtractionError):
+        extract_bom_from_pdf(str(pdf_path))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,43 @@
+"""Utilities shared by the test-suite."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+
+
+def build_pdf_table(path: Path, data: Sequence[Sequence[str]]) -> Path:
+    """Create a simple PDF file containing a table."""
+
+    doc = SimpleDocTemplate(str(path), pagesize=A4)
+    table = Table(data, repeatRows=1)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.black),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+            ]
+        )
+    )
+    doc.build([table])
+    return path
+
+
+def build_pdf_text(path: Path, lines: Iterable[str]) -> Path:
+    """Create a PDF that only contains free text (used for negative tests)."""
+
+    from reportlab.pdfgen import canvas
+
+    c = canvas.Canvas(str(path), pagesize=A4)
+    text_object = c.beginText(40, A4[1] - 50)
+    for line in lines:
+        text_object.textLine(line)
+    c.drawText(text_object)
+    c.showPage()
+    c.save()
+    return path


### PR DESCRIPTION
## Summary
- add a reusable BOM extraction library that parses PDF drawings and normalises detected columns
- expose the extractor via a FastAPI service with an `/extract` endpoint
- provide automated tests that generate sample PDFs and document usage in the README

## Testing
- `pytest` *(fails: missing optional third-party dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd7f8e2f0832c8c69c147cf0f8b23