### PR TITLE
Document Windows virtualenv activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# Stücklisten-Extractor
+
+Diese Anwendung extrahiert aus technischen Zeichnungen im PDF-Format automatisch Stücklisten (Bill of Materials).
+Sie besteht aus einer wiederverwendbaren Python-Bibliothek und einem kleinen FastAPI-Dienst, über den sich die
+Extraktion als Webservice aufrufen lässt.
+
+## Funktionen
+
+- Erkennung gängiger Stücklisten-Tabellen mit deutsch- und englischsprachigen Spaltenüberschriften.
+- Automatische Interpretation wichtiger Spalten wie Position, Artikelnummer, Beschreibung, Menge, Einheit und Material.
+- Robuste PDF-Auswertung auf Basis von [pdfplumber](https://github.com/jsvine/pdfplumber).
+- REST-Schnittstelle (FastAPI) zur Integration in bestehende Systeme.
+- Umfangreiche Tests inklusive Erzeugung von Beispiel-PDFs.
+
+## Installation
+
+1. Optional ein virtuelles Python-Umfeld anlegen:
+
+   ```bash
+   python -m venv .venv
+   ```
+
+   Aktivieren Sie die Umgebung anschließend passend zu Ihrem Betriebssystem:
+
+   - **Linux/macOS (bash/zsh):**
+
+     ```bash
+     source .venv/bin/activate
+     ```
+
+   - **Windows PowerShell:**
+
+     ```powershell
+     .\.venv\Scripts\Activate.ps1
+     ```
+
+   - **Windows-Eingabeaufforderung (cmd):**
+
+     ```bat
+     .\.venv\Scripts\activate.bat
+     ```
+
+2. Abhängigkeiten installieren:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Verwendung der Bibliothek
+
+```python
+from bom_extractor import extract_bom_from_pdf
+
+result = extract_bom_from_pdf("/pfad/zur/zeichnung.pdf")
+for item in result.items:
+    print(item.to_dict())
+```
+
+Die Funktion gibt ein `BOMExtractionResult`-Objekt zurück, welches die erkannten Einträge, die gefundenen Spalten sowie
+Metadaten wie die ausgewerteten Seiten enthält.
+
+## Start des Webservices
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Nach dem Start öffnet `http://127.0.0.1:8000/` eine komfortable Weboberfläche. Dort lassen sich PDF-Zeichnungen bequem
+auswählen und mit einem Klick analysieren. Die extrahierten Stücklisten werden tabellarisch dargestellt,
+Metadaten und erkannte Spalten werden übersichtlich aufbereitet.
+
+Die API kann weiterhin direkt genutzt werden: Unter `http://127.0.0.1:8000/docs` steht die automatische FastAPI-
+Dokumentation zur Verfügung, der Endpunkt `POST /extract` akzeptiert PDF-Dateien als Multipart-Uploads und liefert eine
+strukturierte Antwort.
+
+## Tests
+
+```bash
+pytest
+```
+
+Die Tests erzeugen automatisch Beispiel-PDFs und verifizieren die Extraktionslogik sowie den API-Endpunkt.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi>=0.103,<0.104
+uvicorn[standard]>=0.23,<0.24
+pdfplumber>=0.10,<0.11
+python-multipart>=0.0.6,<0.0.7
+pydantic>=1.10,<2.0
+reportlab>=3.6,<3.7
+pytest>=7.4,<8.0
+httpx>=0.24,<0.25

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application exposing the BOM extraction service."""

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,68 @@
+"""FastAPI entry point for the Stücklisten-Extraktionsdienst."""
+from __future__ import annotations
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+
+from bom_extractor import BOMExtractionError, extract_bom_from_bytes
+from .schemas import BOMResponseModel
+from .ui import WEB_INTERFACE_HTML
+
+app = FastAPI(
+    title="BOM Extractor",
+    description=(
+        "Extrahiert Stücklisten aus technischen Zeichnungen im PDF-Format. "
+        "Die API akzeptiert PDF-Dateien als Multipart-Uploads und liefert eine strukturierte Stückliste zurück."
+    ),
+    version="1.0.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/", response_class=HTMLResponse)
+def render_interface() -> HTMLResponse:
+    """Serve the embedded single-page web interface."""
+
+    return HTMLResponse(content=WEB_INTERFACE_HTML)
+
+
+@app.get("/health")
+def healthcheck() -> dict:
+    """Simple health endpoint that documents the service."""
+
+    return {
+        "status": "ok",
+        "message": "Nutzen Sie POST /extract, um eine Stückliste aus einer PDF zu extrahieren.",
+    }
+
+
+@app.post("/extract", response_model=BOMResponseModel)
+async def extract_bom(file: UploadFile = File(...)) -> BOMResponseModel:
+    """Extract a bill of materials from an uploaded PDF drawing."""
+
+    if not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Bitte laden Sie eine PDF-Datei hoch.")
+
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=400, detail="Die übermittelte Datei ist leer.")
+
+    try:
+        result = extract_bom_from_bytes(content, source=file.filename)
+    except BOMExtractionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=500, detail="Fehler beim Lesen der PDF-Datei.") from exc
+
+    return BOMResponseModel(**result.to_dict())
+
+
+__all__ = ["app"]

--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -1,0 +1,26 @@
+"""Pydantic schemas for the API layer."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+class BOMItemModel(BaseModel):
+    position: Optional[str] = None
+    part_number: Optional[str] = None
+    description: Optional[str] = None
+    quantity: Optional[Union[int, float]] = None
+    unit: Optional[str] = None
+    material: Optional[str] = None
+    comment: Optional[str] = None
+    extras: Dict[str, str] = Field(default_factory=dict)
+
+
+class BOMResponseModel(BaseModel):
+    items: List[BOMItemModel]
+    detected_columns: List[str]
+    metadata: Dict[str, Union[str, List[int], int]]
+
+
+__all__ = ["BOMItemModel", "BOMResponseModel"]

--- a/src/app/ui.py
+++ b/src/app/ui.py
@@ -1,0 +1,584 @@
+"""HTML markup for the embedded web interface."""
+from __future__ import annotations
+
+
+WEB_INTERFACE_HTML = """<!DOCTYPE html>
+<html lang=\"de\">
+<head>
+    <meta charset=\"utf-8\" />
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+    <title>Stücklisten-Extractor</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: \"Inter\", \"Segoe UI\", system-ui, -apple-system, sans-serif;
+            font-size: 16px;
+            line-height: 1.6;
+        }
+
+        body {
+            margin: 0;
+            background: #f3f4f6;
+            color: #1f2937;
+        }
+
+        body.dark {
+            background: #111827;
+            color: #f9fafb;
+        }
+
+        main {
+            max-width: 960px;
+            margin: 0 auto;
+            padding: 2.5rem 1.5rem 3rem;
+        }
+
+        h1 {
+            font-size: 2rem;
+            margin-bottom: 0.75rem;
+            letter-spacing: -0.03em;
+        }
+
+        p.lead {
+            margin-top: 0;
+            margin-bottom: 2rem;
+            color: #4b5563;
+            max-width: 640px;
+        }
+
+        .card {
+            background: rgba(255, 255, 255, 0.92);
+            border-radius: 16px;
+            padding: 1.75rem;
+            margin-top: 1.5rem;
+            box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+            backdrop-filter: blur(6px);
+        }
+
+        body.dark .card {
+            background: rgba(17, 24, 39, 0.85);
+            box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
+        }
+
+        form {
+            display: grid;
+            gap: 1rem;
+        }
+
+        label {
+            font-weight: 600;
+        }
+
+        input[type=\"file\"] {
+            padding: 0.75rem;
+            border: 2px dashed #cbd5f5;
+            border-radius: 12px;
+            cursor: pointer;
+            background: rgba(99, 102, 241, 0.08);
+            transition: border 0.2s ease, background 0.2s ease;
+        }
+
+        input[type=\"file\"]:hover {
+            border-color: #6366f1;
+            background: rgba(99, 102, 241, 0.14);
+        }
+
+        button {
+            justify-self: start;
+            padding: 0.75rem 1.75rem;
+            border-radius: 999px;
+            border: none;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            background: linear-gradient(135deg, #6366f1, #2563eb);
+            color: #ffffff;
+            cursor: pointer;
+            box-shadow: 0 12px 25px rgba(37, 99, 235, 0.35);
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        button:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 16px 30px rgba(37, 99, 235, 0.35);
+        }
+
+        button:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            transform: none;
+            box-shadow: none;
+        }
+
+        .notice {
+            min-height: 2.5rem;
+            border-radius: 12px;
+            padding: 0.85rem 1.1rem;
+            margin-top: 0.5rem;
+            background: rgba(99, 102, 241, 0.08);
+            color: #3730a3;
+            display: flex;
+            align-items: center;
+        }
+
+        .notice.info {
+            background: rgba(59, 130, 246, 0.12);
+            color: #1d4ed8;
+        }
+
+        .notice.success {
+            background: rgba(34, 197, 94, 0.12);
+            color: #15803d;
+        }
+
+        .notice.error {
+            background: rgba(248, 113, 113, 0.12);
+            color: #b91c1c;
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        .result-grid {
+            display: grid;
+            gap: 1.5rem;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        dl.meta {
+            display: grid;
+            grid-template-columns: minmax(120px, 1fr) minmax(160px, 2fr);
+            gap: 0.4rem 1rem;
+            margin: 0;
+        }
+
+        dl.meta dt {
+            font-weight: 600;
+            color: #4338ca;
+        }
+
+        dl.meta dd {
+            margin: 0;
+        }
+
+        ul.tag-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+            padding: 0;
+            margin: 0;
+            list-style: none;
+        }
+
+        ul.tag-list li {
+            background: rgba(37, 99, 235, 0.08);
+            color: #1d4ed8;
+            padding: 0.35rem 0.75rem;
+            border-radius: 999px;
+            font-size: 0.85rem;
+        }
+
+        .table-wrapper {
+            margin-top: 1.75rem;
+            overflow-x: auto;
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.35);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            min-width: 480px;
+        }
+
+        thead {
+            background: linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(59, 130, 246, 0.9));
+            color: #fff;
+        }
+
+        th, td {
+            padding: 0.75rem 0.9rem;
+            text-align: left;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+            vertical-align: top;
+            font-size: 0.95rem;
+        }
+
+        tbody tr:nth-child(even) {
+            background: rgba(99, 102, 241, 0.04);
+        }
+
+        .muted {
+            color: #6b7280;
+        }
+
+        footer {
+            margin-top: 2.5rem;
+            text-align: center;
+            color: #9ca3af;
+            font-size: 0.85rem;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #0f172a;
+                color: #e2e8f0;
+            }
+
+            p.lead {
+                color: #cbd5f5;
+            }
+
+            input[type=\"file\"] {
+                border-color: rgba(99, 102, 241, 0.35);
+                background: rgba(99, 102, 241, 0.12);
+            }
+
+            .card {
+                background: rgba(15, 23, 42, 0.85);
+                box-shadow: 0 18px 40px rgba(2, 6, 23, 0.75);
+            }
+
+            dl.meta dt {
+                color: #a5b4fc;
+            }
+
+            ul.tag-list li {
+                background: rgba(59, 130, 246, 0.12);
+                color: #bfdbfe;
+            }
+
+            tbody tr:nth-child(even) {
+                background: rgba(59, 130, 246, 0.08);
+            }
+
+            th, td {
+                border-bottom-color: rgba(71, 85, 105, 0.35);
+            }
+
+            .muted {
+                color: #94a3b8;
+            }
+
+            footer {
+                color: #64748b;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <header>
+            <h1>Stücklisten-Extractor</h1>
+            <p class=\"lead\">Analysieren Sie technische Zeichnungen im PDF-Format und erhalten Sie eine strukturierte Stückliste direkt im Browser.</p>
+        </header>
+
+        <section class=\"card\">
+            <form id=\"upload-form\">
+                <div>
+                    <label for=\"file\">PDF-Datei hochladen</label>
+                    <input id=\"file\" type=\"file\" accept=\"application/pdf\" required />
+                    <p class=\"muted\">Die Datei wird ausschließlich lokal verarbeitet und nicht gespeichert.</p>
+                </div>
+                <button id=\"submit-button\" type=\"submit\">Stückliste extrahieren</button>
+            </form>
+            <div id=\"status\" class=\"notice\" role=\"status\" aria-live=\"polite\"></div>
+        </section>
+
+        <section id=\"result\" class=\"card hidden\" aria-live=\"polite\">
+            <h2>Ergebnis</h2>
+            <div class=\"result-grid\">
+                <div>
+                    <h3>Metadaten</h3>
+                    <div id=\"metadata-container\">
+                        <dl id=\"metadata-list\" class=\"meta\"></dl>
+                        <p id=\"metadata-empty\" class=\"muted\">Keine Metadaten vorhanden.</p>
+                    </div>
+                </div>
+                <div>
+                    <h3>Erkannte Spalten</h3>
+                    <ul id=\"column-list\" class=\"tag-list\"></ul>
+                </div>
+            </div>
+            <div class=\"table-wrapper\">
+                <table id=\"items-table\" aria-live=\"polite\">
+                    <thead></thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </section>
+
+        <footer>
+            Bereitgestellt vom integrierten FastAPI-Dienst &mdash; Endpunkt: <code>POST /extract</code>
+        </footer>
+    </main>
+
+    <script>
+        (function () {
+            const form = document.getElementById('upload-form');
+            const fileInput = document.getElementById('file');
+            const submitButton = document.getElementById('submit-button');
+            const statusBox = document.getElementById('status');
+            const resultSection = document.getElementById('result');
+            const metadataList = document.getElementById('metadata-list');
+            const metadataEmpty = document.getElementById('metadata-empty');
+            const columnList = document.getElementById('column-list');
+            const tableHead = document.querySelector('#items-table thead');
+            const tableBody = document.querySelector('#items-table tbody');
+
+            const defaultColumns = [
+                { key: 'position', label: 'Position' },
+                { key: 'part_number', label: 'Artikelnummer' },
+                { key: 'description', label: 'Beschreibung' },
+                { key: 'quantity', label: 'Menge' },
+                { key: 'unit', label: 'Einheit' },
+                { key: 'material', label: 'Material' },
+                { key: 'comment', label: 'Kommentar' }
+            ];
+
+            form.addEventListener('submit', async (event) => {
+                event.preventDefault();
+                clearNotice();
+                resultSection.classList.add('hidden');
+
+                const file = fileInput.files[0];
+                if (!file) {
+                    showNotice('Bitte wählen Sie eine PDF-Datei aus.', 'error');
+                    return;
+                }
+                if (!file.name.toLowerCase().endsWith('.pdf')) {
+                    showNotice('Die ausgewählte Datei ist keine PDF.', 'error');
+                    return;
+                }
+
+                const data = new FormData();
+                data.append('file', file);
+
+                setLoading(true);
+                showNotice('Die Datei wird analysiert …', 'info');
+
+                try {
+                    const response = await fetch('/extract', {
+                        method: 'POST',
+                        body: data
+                    });
+
+                    let payload = null;
+                    try {
+                        payload = await response.json();
+                    } catch (parseError) {
+                        payload = null;
+                    }
+
+                    if (!response.ok) {
+                        const detail = payload && payload.detail ? payload.detail : `Die Analyse ist fehlgeschlagen (Status ${response.status}).`;
+                        throw new Error(detail);
+                    }
+
+                    if (!payload || typeof payload !== 'object') {
+                        throw new Error('Unerwartetes Antwortformat.');
+                    }
+
+                    renderResult(payload);
+                    showNotice('Die Stückliste wurde erfolgreich extrahiert.', 'success');
+                } catch (error) {
+                    showNotice(error.message || 'Unbekannter Fehler bei der Analyse.', 'error');
+                } finally {
+                    setLoading(false);
+                }
+            });
+
+            function setLoading(isLoading) {
+                submitButton.disabled = isLoading;
+                fileInput.disabled = isLoading;
+            }
+
+            function showNotice(message, kind) {
+                statusBox.textContent = '';
+                statusBox.className = 'notice ' + kind;
+                statusBox.textContent = message;
+            }
+
+            function clearNotice() {
+                statusBox.textContent = '';
+                statusBox.className = 'notice';
+            }
+
+            function renderResult(data) {
+                if (!data || !Array.isArray(data.items)) {
+                    throw new Error('Unerwartetes Antwortformat.');
+                }
+
+                renderMetadata(data.metadata || {});
+                renderDetectedColumns(data.detected_columns || []);
+                renderTable(data.items || []);
+                resultSection.classList.remove('hidden');
+            }
+
+            function renderMetadata(metadata) {
+                metadataList.innerHTML = '';
+                const entries = Object.entries(metadata || {});
+
+                if (entries.length === 0) {
+                    metadataEmpty.classList.remove('hidden');
+                    return;
+                }
+
+                metadataEmpty.classList.add('hidden');
+
+                entries.forEach(([key, value]) => {
+                    const term = document.createElement('dt');
+                    term.textContent = prettifyLabel(key);
+                    metadataList.appendChild(term);
+
+                    const detail = document.createElement('dd');
+                    detail.textContent = formatValue(value);
+                    metadataList.appendChild(detail);
+                });
+            }
+
+            function renderDetectedColumns(columns) {
+                columnList.innerHTML = '';
+
+                if (!Array.isArray(columns) || columns.length === 0) {
+                    const empty = document.createElement('li');
+                    empty.className = 'muted';
+                    empty.textContent = 'Keine Angabe';
+                    columnList.appendChild(empty);
+                    return;
+                }
+
+                columns.forEach((column) => {
+                    const item = document.createElement('li');
+                    item.textContent = prettifyLabel(column);
+                    columnList.appendChild(item);
+                });
+            }
+
+            function renderTable(items) {
+                tableHead.innerHTML = '';
+                tableBody.innerHTML = '';
+
+                if (!Array.isArray(items) || items.length === 0) {
+                    const row = document.createElement('tr');
+                    const cell = document.createElement('td');
+                    cell.colSpan = 1;
+                    cell.textContent = 'Keine Einträge gefunden.';
+                    row.appendChild(cell);
+                    tableBody.appendChild(row);
+                    return;
+                }
+
+                const availableColumns = [];
+
+                defaultColumns.forEach((column) => {
+                    const hasValues = items.some((item) => hasValue(item[column.key]));
+                    if (hasValues) {
+                        availableColumns.push({ ...column, fromExtras: false });
+                    }
+                });
+
+                const extraKeys = new Set();
+
+                items.forEach((item) => {
+                    if (item.extras && typeof item.extras === 'object') {
+                        Object.entries(item.extras).forEach(([key, value]) => {
+                            if (hasValue(value)) {
+                                extraKeys.add(key);
+                            }
+                        });
+                    }
+
+                    Object.keys(item).forEach((key) => {
+                        if (key === 'extras') {
+                            return;
+                        }
+                        if (defaultColumns.some((column) => column.key === key)) {
+                            return;
+                        }
+                        if (hasValue(item[key])) {
+                            extraKeys.add(key);
+                        }
+                    });
+                });
+
+                Array.from(extraKeys).sort((a, b) => a.localeCompare(b, 'de')).forEach((key) => {
+                    availableColumns.push({
+                        key: key,
+                        label: prettifyLabel(key),
+                        fromExtras: !defaultColumns.some((column) => column.key === key)
+                    });
+                });
+
+                if (availableColumns.length === 0) {
+                    availableColumns.push({ key: 'description', label: 'Beschreibung', fromExtras: false });
+                }
+
+                const headerRow = document.createElement('tr');
+                availableColumns.forEach((column) => {
+                    const th = document.createElement('th');
+                    th.scope = 'col';
+                    th.textContent = column.label;
+                    headerRow.appendChild(th);
+                });
+                tableHead.appendChild(headerRow);
+
+                items.forEach((item) => {
+                    const row = document.createElement('tr');
+                    availableColumns.forEach((column) => {
+                        const td = document.createElement('td');
+                        let value;
+                        if (column.fromExtras && item.extras && Object.prototype.hasOwnProperty.call(item.extras, column.key)) {
+                            value = item.extras[column.key];
+                        } else {
+                            value = item[column.key];
+                        }
+                        td.textContent = formatValue(value);
+                        row.appendChild(td);
+                    });
+                    tableBody.appendChild(row);
+                });
+            }
+
+            function prettifyLabel(label) {
+                return String(label)
+                    .replace(/_/g, ' ')
+                    .replace(/\b\w/g, (char) => char.toUpperCase());
+            }
+
+            function hasValue(value) {
+                if (value === null || value === undefined) {
+                    return false;
+                }
+                if (typeof value === 'number') {
+                    return true;
+                }
+                if (Array.isArray(value)) {
+                    return value.length > 0;
+                }
+                if (typeof value === 'string') {
+                    return value.trim() !== '';
+                }
+                return true;
+            }
+
+            function formatValue(value) {
+                if (value === null || value === undefined) {
+                    return '';
+                }
+                if (Array.isArray(value)) {
+                    return value.map((entry) => formatValue(entry)).join(', ');
+                }
+                if (typeof value === 'number') {
+                    return value.toLocaleString('de-DE');
+                }
+                return String(value);
+            }
+        })();
+    </script>
+</body>
+</html>
+"""
+
+
+__all__ = ["WEB_INTERFACE_HTML"]

--- a/src/bom_extractor/__init__.py
+++ b/src/bom_extractor/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities for extracting bills of materials (Stücklisten) from PDF drawings."""
+
+from .extractor import (
+    BOMExtractionError,
+    BOMExtractionResult,
+    BOMItem,
+    extract_bom_from_bytes,
+    extract_bom_from_pdf,
+)
+
+__all__ = [
+    "BOMItem",
+    "BOMExtractionResult",
+    "BOMExtractionError",
+    "extract_bom_from_pdf",
+    "extract_bom_from_bytes",
+]

--- a/src/bom_extractor/extractor.py
+++ b/src/bom_extractor/extractor.py
@@ -1,0 +1,383 @@
+"""Core logic for extracting bills of materials from PDF engineering drawings."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import io
+import re
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import pdfplumber
+
+__all__ = [
+    "BOMItem",
+    "BOMExtractionResult",
+    "BOMExtractionError",
+    "extract_bom_from_pdf",
+    "extract_bom_from_bytes",
+]
+
+
+TABLE_SETTINGS: Sequence[Dict[str, Union[str, float]]] = (
+    {"vertical_strategy": "lines", "horizontal_strategy": "lines"},
+    {"vertical_strategy": "text", "horizontal_strategy": "text"},
+    {"vertical_strategy": "lines", "horizontal_strategy": "text"},
+)
+
+
+HEADER_ALIASES: Dict[str, Tuple[str, ...]] = {
+    "position": (
+        "position",
+        "pos",
+        "pos.",
+        "item",
+        "itemno",
+        "item no",
+        "item no.",
+        "no",
+        "nr",
+        "index",
+    ),
+    "part_number": (
+        "part",
+        "partno",
+        "part no",
+        "part-number",
+        "article",
+        "artikel",
+        "artnr",
+        "art.nr",
+        "drawing",
+        "drawing no",
+        "zeichnungs",
+        "zeichnungsnr",
+        "zeichnung",
+        "bestell",
+        "order",
+        "item code",
+        "teilenummer",
+    ),
+    "description": (
+        "description",
+        "descr",
+        "desc",
+        "bezeichnung",
+        "benennung",
+        "designation",
+        "title",
+        "titel",
+        "beschreibung",
+    ),
+    "quantity": (
+        "qty",
+        "qty.",
+        "quantity",
+        "menge",
+        "anzahl",
+        "stück",
+        "stückzahl",
+        "stk",
+        "st",
+        "pcs",
+        "qty/qty",
+    ),
+    "unit": (
+        "unit",
+        "einheit",
+        "uom",
+        "ein",
+        "maßeinheit",
+    ),
+    "material": (
+        "material",
+        "werkstoff",
+        "mat",
+    ),
+    "comment": (
+        "comment",
+        "comments",
+        "bemerkung",
+        "bemerkungen",
+        "note",
+        "notes",
+        "remark",
+        "remarks",
+    ),
+}
+
+# Regular expression used to detect numbers (supporting comma as decimal separator)
+QUANTITY_RE = re.compile(
+    r"(?P<value>-?\d+(?:[\.,]\d+)?)\s*(?P<unit>[a-zA-Z%\u00b0\/]*)"
+)
+
+
+class BOMExtractionError(RuntimeError):
+    """Raised when the extractor cannot locate a valid bill of materials table."""
+
+
+@dataclass
+class BOMItem:
+    """Container for a single bill of materials entry."""
+
+    position: Optional[str] = None
+    part_number: Optional[str] = None
+    description: Optional[str] = None
+    quantity: Optional[Union[int, float]] = None
+    unit: Optional[str] = None
+    material: Optional[str] = None
+    comment: Optional[str] = None
+    extras: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Union[str, int, float, Dict[str, str], None]]:
+        """Convert the item into a serialisable dictionary."""
+
+        data = {
+            "position": self.position,
+            "part_number": self.part_number,
+            "description": self.description,
+            "quantity": self.quantity,
+            "unit": self.unit,
+            "material": self.material,
+            "comment": self.comment,
+            "extras": {k: v for k, v in self.extras.items() if v},
+        }
+        return {k: v for k, v in data.items() if v is not None and (v != {} or k == "extras")}
+
+
+@dataclass
+class BOMExtractionResult:
+    """Represents a complete bill of materials extracted from a drawing."""
+
+    items: List[BOMItem]
+    detected_columns: List[str]
+    metadata: Dict[str, Union[str, List[int], int]] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "items": [item.to_dict() for item in self.items],
+            "detected_columns": self.detected_columns,
+            "metadata": self.metadata,
+        }
+
+
+def extract_bom_from_pdf(path: Union[str, io.BytesIO]) -> BOMExtractionResult:
+    """Extract a bill of materials from a PDF file located at *path*."""
+
+    with pdfplumber.open(path) as pdf:
+        return _extract_from_pdf_document(pdf, source=getattr(path, "name", str(path)))
+
+
+def extract_bom_from_bytes(content: bytes, source: Optional[str] = None) -> BOMExtractionResult:
+    """Extract a bill of materials from in-memory PDF data."""
+
+    buffer = io.BytesIO(content)
+    buffer.name = source or "<memory>"
+    with pdfplumber.open(buffer) as pdf:
+        return _extract_from_pdf_document(pdf, source=buffer.name)
+
+
+def _extract_from_pdf_document(pdf: pdfplumber.PDF, source: Optional[str]) -> BOMExtractionResult:
+    items: List[BOMItem] = []
+    detected_columns: List[str] = []
+    pages_used: List[int] = []
+    tables_seen = 0
+
+    for page_index, page in enumerate(pdf.pages, start=1):
+        for table in _iter_tables(page):
+            tables_seen += 1
+            table_items, columns = _process_table(table)
+            if table_items:
+                items.extend(table_items)
+                detected_columns.extend(col for col in columns if col not in detected_columns)
+                pages_used.append(page_index)
+
+    if not items:
+        raise BOMExtractionError(
+            "Keine Stückliste in der PDF gefunden. Bitte stellen Sie sicher, dass die Zeichnung eine tabellarische "
+            "Stückliste mit Spaltenüberschriften enthält."
+        )
+
+    metadata: Dict[str, Union[str, List[int], int]] = {
+        "source": source or "<unknown>",
+        "pages": sorted(set(pages_used)),
+        "tables_checked": tables_seen,
+    }
+
+    return BOMExtractionResult(items=items, detected_columns=detected_columns, metadata=metadata)
+
+
+def _iter_tables(page: pdfplumber.page.Page) -> Iterable[List[List[Optional[str]]]]:
+    """Yield tables extracted from a PDF page using different detection strategies."""
+
+    yielded: List[List[List[Optional[str]]]] = []
+    for settings in TABLE_SETTINGS:
+        try:
+            tables = page.extract_tables(table_settings=settings)
+        except NotImplementedError:
+            continue
+        if not tables:
+            continue
+        for table in tables:
+            # Avoid returning duplicate tables produced by different strategies.
+            if table not in yielded:
+                yielded.append(table)
+                yield table
+
+
+def _process_table(raw_table: Sequence[Sequence[Optional[str]]]) -> Tuple[List[BOMItem], List[str]]:
+    """Attempt to interpret a raw table as a bill of materials."""
+
+    cleaned_table = [_clean_row(row) for row in raw_table if any(_cell_has_content(cell) for cell in row)]
+    if not cleaned_table:
+        return [], []
+
+    header_index, header_map, header_names = _find_header_row(cleaned_table)
+    if header_index is None:
+        return [], []
+
+    data_rows = cleaned_table[header_index + 1 :]
+    if not data_rows:
+        return [], []
+
+    items: List[BOMItem] = []
+    for row in data_rows:
+        item = _row_to_item(row, header_map, header_names)
+        if item:
+            items.append(item)
+
+    normalized_columns = sorted(set(header_map.values()))
+    return items, normalized_columns
+
+
+def _clean_row(row: Sequence[Optional[str]]) -> List[str]:
+    return [_normalise_cell(cell) for cell in row]
+
+
+def _normalise_cell(cell: Optional[str]) -> str:
+    if cell is None:
+        return ""
+    text = str(cell)
+    text = text.replace("\n", " ")
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _cell_has_content(cell: Optional[str]) -> bool:
+    return bool(_normalise_cell(cell))
+
+
+def _find_header_row(table: Sequence[Sequence[str]]) -> Tuple[Optional[int], Dict[int, str], Dict[int, str]]:
+    """Locate the header row within a table and return column mappings."""
+
+    best_index: Optional[int] = None
+    best_map: Dict[int, str] = {}
+    best_header_names: Dict[int, str] = {}
+    best_score = 0
+
+    for idx, row in enumerate(table):
+        mapping: Dict[int, str] = {}
+        names: Dict[int, str] = {}
+        score = 0
+
+        for col_index, cell in enumerate(row):
+            if not cell:
+                continue
+            normalised = _normalise_header(cell)
+            if not normalised:
+                continue
+            match = _match_header(normalised)
+            names[col_index] = normalised
+            if match and match not in mapping.values():
+                mapping[col_index] = match
+                score += 1
+
+        # Require at least two recognised columns for a confident BOM header.
+        if score >= 2 and score > best_score:
+            best_index = idx
+            best_map = mapping
+            best_header_names = names
+            best_score = score
+
+    return best_index, best_map, best_header_names
+
+
+def _normalise_header(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _match_header(value: str) -> Optional[str]:
+    for canonical, aliases in HEADER_ALIASES.items():
+        if value in aliases:
+            return canonical
+    return None
+
+
+def _row_to_item(row: Sequence[str], header_map: Dict[int, str], header_names: Dict[int, str]) -> Optional[BOMItem]:
+    recognised: Dict[str, str] = {}
+    extras: Dict[str, str] = {}
+
+    for idx, cell in enumerate(row):
+        if not cell:
+            continue
+        if idx in header_map:
+            recognised[header_map[idx]] = cell
+        else:
+            header_name = header_names.get(idx, f"column_{idx}")
+            extras[header_name] = cell
+
+    if not recognised and not extras:
+        return None
+
+    quantity_value: Optional[Union[int, float]] = None
+    unit_value: Optional[str] = None
+    if "quantity" in recognised:
+        quantity_value, unit_value = _parse_quantity(recognised.get("quantity"))
+
+    # If the unit column exists separately, it has precedence
+    if "unit" in recognised and recognised["unit"]:
+        unit_value = recognised["unit"]
+
+    item = BOMItem(
+        position=recognised.get("position"),
+        part_number=recognised.get("part_number"),
+        description=recognised.get("description"),
+        quantity=quantity_value,
+        unit=unit_value,
+        material=recognised.get("material"),
+        comment=recognised.get("comment"),
+        extras=extras,
+    )
+
+    # If a recognised field still contains data that should be treated as extra (e.g. quantity without value)
+    # we keep the original text in extras for traceability.
+    for key, value in recognised.items():
+        if key not in {"position", "part_number", "description", "quantity", "unit", "material", "comment"}:
+            item.extras[key] = value
+
+    # If we failed to parse a numeric quantity keep the raw text inside extras.
+    if "quantity" in recognised and quantity_value is None:
+        item.extras.setdefault("quantity_raw", recognised["quantity"])
+
+    return item
+
+
+def _parse_quantity(value: Optional[str]) -> Tuple[Optional[Union[int, float]], Optional[str]]:
+    if not value:
+        return None, None
+
+    match = QUANTITY_RE.search(value)
+    if not match:
+        return None, None
+
+    raw_value = match.group("value").replace(",", ".")
+    try:
+        numeric = float(raw_value)
+    except ValueError:
+        return None, match.group("unit") or None
+
+    if numeric.is_integer():
+        numeric_value: Union[int, float] = int(numeric)
+    else:
+        numeric_value = numeric
+
+    unit = match.group("unit") or None
+    return numeric_value, unit

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from .utils import build_pdf_table
+
+
+client = TestClient(app)
+
+
+def test_extract_endpoint(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "bom.pdf"
+    data = [
+        ["Item", "Qty", "Description"],
+        ["1", "5", "Washer"],
+        ["2", "3", "Screw"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    with pdf_path.open("rb") as pdf_file:
+        response = client.post(
+            "/extract", files={"file": (pdf_path.name, pdf_file, "application/pdf")}
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"][0]["description"] == "Washer"
+    assert payload["items"][0]["quantity"] == 5
+    assert payload["metadata"]["source"] == "bom.pdf"
+
+
+def test_web_interface_served() -> None:
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    assert "Stücklisten-Extractor" in response.text
+    assert "upload-form" in response.text

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bom_extractor import BOMExtractionError, extract_bom_from_pdf
+from .utils import build_pdf_table, build_pdf_text
+
+
+def test_extract_basic_table(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "drawing.pdf"
+    data = [
+        ["Item", "Qty", "Description", "Material"],
+        ["1", "4", "Bolt M8", "Steel"],
+        ["2", "2", "Nut M8", "Steel"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    result = extract_bom_from_pdf(str(pdf_path))
+
+    assert result.detected_columns == ["description", "material", "position", "quantity"]
+    assert len(result.items) == 2
+    first = result.items[0]
+    assert first.position == "1"
+    assert first.description == "Bolt M8"
+    assert first.material == "Steel"
+    assert first.quantity == 4
+
+
+def test_extract_german_headers(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "zeichnung.pdf"
+    data = [
+        ["Pos.", "Benennung", "Menge", "Einheit"],
+        ["10", "Schraube M10", "12 Stk", "Stk"],
+        ["20", "Mutter M10", "8", "Stk"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    result = extract_bom_from_pdf(str(pdf_path))
+
+    assert len(result.items) == 2
+    first = result.items[0]
+    assert first.position == "10"
+    assert first.quantity == 12
+    assert first.unit == "Stk"
+
+
+def test_extract_raises_when_no_table(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "text.pdf"
+    build_pdf_text(pdf_path, ["Dies ist nur eine Beschreibung ohne Tabelle."])
+
+    with pytest.raises(BOMExtractionError):
+        extract_bom_from_pdf(str(pdf_path))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,43 @@
+"""Utilities shared by the test-suite."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+
+
+def build_pdf_table(path: Path, data: Sequence[Sequence[str]]) -> Path:
+    """Create a simple PDF file containing a table."""
+
+    doc = SimpleDocTemplate(str(path), pagesize=A4)
+    table = Table(data, repeatRows=1)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.black),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+            ]
+        )
+    )
+    doc.build([table])
+    return path
+
+
+def build_pdf_text(path: Path, lines: Iterable[str]) -> Path:
+    """Create a PDF that only contains free text (used for negative tests)."""
+
+    from reportlab.pdfgen import canvas
+
+    c = canvas.Canvas(str(path), pagesize=A4)
+    text_object = c.beginText(40, A4[1] - 50)
+    for line in lines:
+        text_object.textLine(line)
+    c.drawText(text_object)
+    c.showPage()
+    c.save()
+    return path


### PR DESCRIPTION
## Summary
- add a reusable BOM extraction library that parses PDF drawings and normalises detected columns
- expose the extractor via a FastAPI service with an `/extract` endpoint and serve a polished browser UI at `/`
- provide automated tests that generate sample PDFs, validate the extractor and API behaviour, and cover the UI endpoint
- document platform-specific virtualenv activation commands to help Windows users follow the setup instructions

## Testing
- `pytest` *(fails: missing optional third-party dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd7f8e2f0832c8c69c147cf0f8b23