### PR TITLE
Add adaptive learning feedback and user evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# Stücklisten-Extractor
+
+Diese Anwendung extrahiert aus technischen Zeichnungen im PDF-Format automatisch Stücklisten (Bill of Materials).
+Sie besteht aus einer wiederverwendbaren Python-Bibliothek und einem kleinen FastAPI-Dienst, über den sich die
+Extraktion als Webservice aufrufen lässt.
+
+## Funktionen
+
+- Erkennung gängiger Stücklisten-Tabellen mit deutsch- und englischsprachigen Spaltenüberschriften.
+- Automatische Interpretation wichtiger Spalten wie Position, Artikelnummer, Beschreibung, Menge, Einheit und Material.
+- Erstellung einer Stückliste selbst dann, wenn keine Tabelle vorhanden ist – Beschriftungen, Callouts und wiederkehrende
+  Geometrien werden analysiert und zu plausiblen Einträgen zusammengeführt.
+- Spezielle Kennzeichnung typischer Rohrleitungsbauteile wie Rohrenden, Rohre, Rohrbögen, Bleche und Flansche – sowohl in
+  Tabellen als auch in interpretierten Texten und Geometrien.
+- Selbstlernende Vertrauensbewertung: Die Weboberfläche bietet einen Bewertungsbereich, über den Anwender jede Position als
+  korrekt oder überprüfungsbedürftig markieren können. Das System speichert das Feedback, passt seine Gewichtungen an und
+  zeigt nachvollziehbare Erfolgsstatistiken an.
+- Robuste PDF-Auswertung auf Basis von [pdfplumber](https://github.com/jsvine/pdfplumber).
+- REST-Schnittstelle (FastAPI) zur Integration in bestehende Systeme.
+- Umfangreiche Tests inklusive Erzeugung von Beispiel-PDFs.
+
+## Installation
+
+1. Optional ein virtuelles Python-Umfeld anlegen:
+
+   ```bash
+   python -m venv .venv
+   ```
+
+   Aktivieren Sie die Umgebung anschließend passend zu Ihrem Betriebssystem:
+
+   - **Linux/macOS (bash/zsh):**
+
+     ```bash
+     source .venv/bin/activate
+     ```
+
+   - **Windows PowerShell:**
+
+     ```powershell
+     .\.venv\Scripts\Activate.ps1
+     ```
+
+   - **Windows-Eingabeaufforderung (cmd):**
+
+     ```bat
+     .\.venv\Scripts\activate.bat
+     ```
+
+2. Abhängigkeiten installieren:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Verwendung der Bibliothek
+
+```python
+from bom_extractor import extract_bom_from_pdf
+
+result = extract_bom_from_pdf("/pfad/zur/zeichnung.pdf")
+for item in result.items:
+    print(item.to_dict())
+```
+
+Die Funktion gibt ein `BOMExtractionResult`-Objekt zurück, welches die erkannten Einträge, die gefundenen Spalten sowie
+Metadaten wie die ausgewerteten Seiten enthält.
+
+Auch Zeichnungen ohne tabellarische Stückliste werden verarbeitet: Die Bibliothek interpretiert nummerierte Callouts,
+freie Textlisten sowie wiederkehrende geometrische Formen und erstellt daraus eine synthetische Stückliste. Über das
+Metadatenfeld `mode` lässt sich erkennen, ob eine Tabelle (`table`) oder eine interpretierte Liste (`interpreted`)
+zurückgegeben wurde. Weitere Metadaten wie `annotation_items` und `geometry_items` geben an, wie viele Einträge aus
+Text- bzw. Geometrieanalyse stammen.
+
+## Start des Webservices
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Nach dem Start öffnet `http://127.0.0.1:8000/` eine komfortable Weboberfläche. Dort lassen sich PDF-Zeichnungen bequem
+auswählen und mit einem Klick analysieren. Die extrahierten Stücklisten werden tabellarisch dargestellt,
+Metadaten und erkannte Spalten werden übersichtlich aufbereitet. Zusätzlich steht ein Bewertungsbereich zur Verfügung,
+in dem Sie jede Zeile als korrekt oder zu prüfen markieren können. Das adaptive Lernmodell passt die
+Vertrauenswerte in Echtzeit an und präsentiert eine kurze Statistik über die bislang eingegangenen Rückmeldungen.
+
+Die API kann weiterhin direkt genutzt werden: Unter `http://127.0.0.1:8000/docs` steht die automatische FastAPI-
+Dokumentation zur Verfügung, der Endpunkt `POST /extract` akzeptiert PDF-Dateien als Multipart-Uploads und liefert eine
+strukturierte Antwort.
+
+## Tests
+
+```bash
+pytest
+```
+
+Die Tests erzeugen automatisch Beispiel-PDFs und verifizieren die Extraktionslogik sowie den API-Endpunkt.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application exposing the BOM extraction service."""

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,104 @@
+"""FastAPI entry point for the Stücklisten-Extraktionsdienst."""
+from __future__ import annotations
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+
+from bom_extractor import BOMExtractionError, BOMItem, extract_bom_from_bytes
+from bom_extractor.learning import get_learning_engine
+from .schemas import (
+    BOMResponseModel,
+    FeedbackRequestModel,
+    FeedbackResponseModel,
+    FeedbackSummaryModel,
+)
+from .ui import WEB_INTERFACE_HTML
+
+app = FastAPI(
+    title="BOM Extractor",
+    description=(
+        "Extrahiert Stücklisten aus technischen Zeichnungen im PDF-Format. "
+        "Die API akzeptiert PDF-Dateien als Multipart-Uploads und liefert eine strukturierte Stückliste zurück."
+    ),
+    version="1.0.0",
+)
+
+learning_engine = get_learning_engine()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/", response_class=HTMLResponse)
+def render_interface() -> HTMLResponse:
+    """Serve the embedded single-page web interface."""
+
+    return HTMLResponse(content=WEB_INTERFACE_HTML)
+
+
+@app.get("/health")
+def healthcheck() -> dict:
+    """Simple health endpoint that documents the service."""
+
+    return {
+        "status": "ok",
+        "message": "Nutzen Sie POST /extract, um eine Stückliste aus einer PDF zu extrahieren.",
+    }
+
+
+@app.post("/extract", response_model=BOMResponseModel)
+async def extract_bom(file: UploadFile = File(...)) -> BOMResponseModel:
+    """Extract a bill of materials from an uploaded PDF drawing."""
+
+    if not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Bitte laden Sie eine PDF-Datei hoch.")
+
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=400, detail="Die übermittelte Datei ist leer.")
+
+    try:
+        result = extract_bom_from_bytes(content, source=file.filename)
+    except BOMExtractionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=500, detail="Fehler beim Lesen der PDF-Datei.") from exc
+
+    return BOMResponseModel(**result.to_dict())
+
+
+@app.post("/feedback", response_model=FeedbackResponseModel)
+def submit_feedback(payload: FeedbackRequestModel) -> FeedbackResponseModel:
+    """Receive user feedback about extracted BOM entries and update the learner."""
+
+    if not payload.ratings:
+        raise HTTPException(status_code=400, detail="Keine Bewertungen übermittelt.")
+
+    ratings = []
+    for entry in payload.ratings:
+        item = BOMItem(**entry.item.dict())
+        ratings.append((item, entry.correct))
+
+    metadata = dict(payload.metadata or {})
+    if payload.document and "document" not in metadata:
+        metadata["document"] = payload.document
+
+    summary = learning_engine.record_feedback(ratings, metadata=metadata)
+    return FeedbackResponseModel(status="ok", summary=summary)
+
+
+@app.get("/feedback/summary", response_model=FeedbackSummaryModel)
+def get_feedback_summary() -> FeedbackSummaryModel:
+    """Return the aggregated learning summary."""
+
+    summary = learning_engine.summary()
+    return FeedbackSummaryModel(**summary)
+
+
+__all__ = ["app"]

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,65 @@
+"""Pydantic schemas for the API layer."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+class BOMItemModel(BaseModel):
+    position: Optional[str] = None
+    part_number: Optional[str] = None
+    description: Optional[str] = None
+    quantity: Optional[Union[int, float]] = None
+    unit: Optional[str] = None
+    material: Optional[str] = None
+    comment: Optional[str] = None
+    confidence: Optional[float] = None
+    extras: Dict[str, str] = Field(default_factory=dict)
+
+
+class BOMResponseModel(BaseModel):
+    items: List[BOMItemModel]
+    detected_columns: List[str]
+    metadata: Dict[str, Union[int, float, List[int], str]]
+
+
+class FeedbackRatingModel(BaseModel):
+    item: BOMItemModel
+    correct: bool
+    note: Optional[str] = None
+
+
+class FeedbackRequestModel(BaseModel):
+    document: Optional[str] = None
+    ratings: List[FeedbackRatingModel]
+    metadata: Optional[Dict[str, Union[int, float, List[int], str]]] = None
+
+
+class FeedbackFeatureModel(BaseModel):
+    feature: str
+    label: str
+    support: int
+    success_rate: float
+
+
+class FeedbackSummaryModel(BaseModel):
+    total_feedback: int
+    success_rate: float
+    top_features: List[FeedbackFeatureModel]
+
+
+class FeedbackResponseModel(BaseModel):
+    status: str
+    summary: FeedbackSummaryModel
+
+
+__all__ = [
+    "BOMItemModel",
+    "BOMResponseModel",
+    "FeedbackRatingModel",
+    "FeedbackRequestModel",
+    "FeedbackFeatureModel",
+    "FeedbackSummaryModel",
+    "FeedbackResponseModel",
+]

--- a/app/ui.py
+++ b/app/ui.py
@@ -1,0 +1,945 @@
+"""HTML markup for the embedded web interface."""
+from __future__ import annotations
+
+
+WEB_INTERFACE_HTML = """<!DOCTYPE html>
+<html lang=\"de\">
+<head>
+    <meta charset=\"utf-8\" />
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+    <title>Stücklisten-Extractor</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: \"Inter\", \"Segoe UI\", system-ui, -apple-system, sans-serif;
+            font-size: 16px;
+            line-height: 1.6;
+        }
+
+        body {
+            margin: 0;
+            background: #f3f4f6;
+            color: #1f2937;
+        }
+
+        body.dark {
+            background: #111827;
+            color: #f9fafb;
+        }
+
+        main {
+            max-width: 960px;
+            margin: 0 auto;
+            padding: 2.5rem 1.5rem 3rem;
+        }
+
+        h1 {
+            font-size: 2rem;
+            margin-bottom: 0.75rem;
+            letter-spacing: -0.03em;
+        }
+
+        p.lead {
+            margin-top: 0;
+            margin-bottom: 2rem;
+            color: #4b5563;
+            max-width: 640px;
+        }
+
+        .card {
+            background: rgba(255, 255, 255, 0.92);
+            border-radius: 16px;
+            padding: 1.75rem;
+            margin-top: 1.5rem;
+            box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+            backdrop-filter: blur(6px);
+        }
+
+        body.dark .card {
+            background: rgba(17, 24, 39, 0.85);
+            box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
+        }
+
+        form {
+            display: grid;
+            gap: 1rem;
+        }
+
+        label {
+            font-weight: 600;
+        }
+
+        input[type=\"file\"] {
+            padding: 0.75rem;
+            border: 2px dashed #cbd5f5;
+            border-radius: 12px;
+            cursor: pointer;
+            background: rgba(99, 102, 241, 0.08);
+            transition: border 0.2s ease, background 0.2s ease;
+        }
+
+        input[type=\"file\"]:hover {
+            border-color: #6366f1;
+            background: rgba(99, 102, 241, 0.14);
+        }
+
+        button {
+            justify-self: start;
+            padding: 0.75rem 1.75rem;
+            border-radius: 999px;
+            border: none;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            background: linear-gradient(135deg, #6366f1, #2563eb);
+            color: #ffffff;
+            cursor: pointer;
+            box-shadow: 0 12px 25px rgba(37, 99, 235, 0.35);
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        button:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 16px 30px rgba(37, 99, 235, 0.35);
+        }
+
+        button:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            transform: none;
+            box-shadow: none;
+        }
+
+        .notice {
+            min-height: 2.5rem;
+            border-radius: 12px;
+            padding: 0.85rem 1.1rem;
+            margin-top: 0.5rem;
+            background: rgba(99, 102, 241, 0.08);
+            color: #3730a3;
+            display: flex;
+            align-items: center;
+        }
+
+        .notice.info {
+            background: rgba(59, 130, 246, 0.12);
+            color: #1d4ed8;
+        }
+
+        .notice.success {
+            background: rgba(34, 197, 94, 0.12);
+            color: #15803d;
+        }
+
+        .notice.error {
+            background: rgba(248, 113, 113, 0.12);
+            color: #b91c1c;
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        .result-grid {
+            display: grid;
+            gap: 1.5rem;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        dl.meta {
+            display: grid;
+            grid-template-columns: minmax(120px, 1fr) minmax(160px, 2fr);
+            gap: 0.4rem 1rem;
+            margin: 0;
+        }
+
+        dl.meta dt {
+            font-weight: 600;
+            color: #4338ca;
+        }
+
+        dl.meta dd {
+            margin: 0;
+        }
+
+        ul.tag-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+            padding: 0;
+            margin: 0;
+            list-style: none;
+        }
+
+        ul.tag-list li {
+            background: rgba(37, 99, 235, 0.08);
+            color: #1d4ed8;
+            padding: 0.35rem 0.75rem;
+            border-radius: 999px;
+            font-size: 0.85rem;
+        }
+
+        .table-wrapper {
+            margin-top: 1.75rem;
+            overflow-x: auto;
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.35);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            min-width: 480px;
+        }
+
+        thead {
+            background: linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(59, 130, 246, 0.9));
+            color: #fff;
+        }
+
+        th, td {
+            padding: 0.75rem 0.9rem;
+            text-align: left;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+            vertical-align: top;
+            font-size: 0.95rem;
+        }
+
+        .feedback-panel {
+            margin-top: 1.75rem;
+            padding-top: 1.25rem;
+            border-top: 1px solid rgba(148, 163, 184, 0.35);
+        }
+
+        .feedback-panel h3 {
+            margin-top: 0;
+            margin-bottom: 0.75rem;
+        }
+
+        .feedback-panel p {
+            margin-top: 0;
+            margin-bottom: 0.75rem;
+        }
+
+        .feedback-actions {
+            display: inline-flex;
+            gap: 0.5rem;
+        }
+
+        .feedback-button {
+            border: none;
+            border-radius: 999px;
+            padding: 0.45rem 0.75rem;
+            cursor: pointer;
+            font-size: 0.95rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            background: rgba(99, 102, 241, 0.12);
+            color: #1d4ed8;
+            transition: transform 0.1s ease, background 0.1s ease;
+        }
+
+        .feedback-button:hover {
+            transform: translateY(-1px);
+            background: rgba(99, 102, 241, 0.18);
+        }
+
+        .feedback-button.is-active {
+            background: linear-gradient(135deg, #22c55e, #16a34a);
+            color: #ffffff;
+            box-shadow: 0 10px 20px rgba(34, 197, 94, 0.35);
+        }
+
+        .feedback-button.reject.is-active {
+            background: linear-gradient(135deg, #ef4444, #dc2626);
+            box-shadow: 0 10px 20px rgba(239, 68, 68, 0.35);
+        }
+
+        .feedback-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            align-items: center;
+            margin-top: 1rem;
+        }
+
+        .feedback-controls button {
+            margin-top: 0.25rem;
+        }
+
+        .feedback-summary {
+            margin-top: 0.75rem;
+            color: #4338ca;
+            font-size: 0.9rem;
+        }
+
+        .feedback-notice {
+            margin-top: 0.75rem;
+        }
+
+        .small-note {
+            font-size: 0.85rem;
+            color: #6b7280;
+        }
+
+        tbody tr:nth-child(even) {
+            background: rgba(99, 102, 241, 0.04);
+        }
+
+        .muted {
+            color: #6b7280;
+        }
+
+        footer {
+            margin-top: 2.5rem;
+            text-align: center;
+            color: #9ca3af;
+            font-size: 0.85rem;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #0f172a;
+                color: #e2e8f0;
+            }
+
+            p.lead {
+                color: #cbd5f5;
+            }
+
+            input[type=\"file\"] {
+                border-color: rgba(99, 102, 241, 0.35);
+                background: rgba(99, 102, 241, 0.12);
+            }
+
+            .card {
+                background: rgba(15, 23, 42, 0.85);
+                box-shadow: 0 18px 40px rgba(2, 6, 23, 0.75);
+            }
+
+            dl.meta dt {
+                color: #a5b4fc;
+            }
+
+            ul.tag-list li {
+                background: rgba(59, 130, 246, 0.12);
+                color: #bfdbfe;
+            }
+
+            tbody tr:nth-child(even) {
+                background: rgba(59, 130, 246, 0.08);
+            }
+
+            th, td {
+                border-bottom-color: rgba(71, 85, 105, 0.35);
+            }
+
+            .muted {
+                color: #94a3b8;
+            }
+
+            .feedback-button {
+                background: rgba(59, 130, 246, 0.18);
+                color: #c7d2fe;
+            }
+
+            .feedback-button:hover {
+                background: rgba(59, 130, 246, 0.25);
+            }
+
+            .feedback-summary {
+                color: #a5b4fc;
+            }
+
+            footer {
+                color: #64748b;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <header>
+            <h1>Stücklisten-Extractor</h1>
+            <p class=\"lead\">Analysieren Sie technische Zeichnungen im PDF-Format und erhalten Sie eine strukturierte Stückliste direkt im Browser.</p>
+        </header>
+
+        <section class=\"card\">
+            <form id=\"upload-form\">
+                <div>
+                    <label for=\"file\">PDF-Datei hochladen</label>
+                    <input id=\"file\" type=\"file\" accept=\"application/pdf\" required />
+                    <p class=\"muted\">Die Datei wird ausschließlich lokal verarbeitet und nicht gespeichert.</p>
+                </div>
+                <button id=\"submit-button\" type=\"submit\">Stückliste extrahieren</button>
+            </form>
+            <div id=\"status\" class=\"notice\" role=\"status\" aria-live=\"polite\"></div>
+        </section>
+
+        <section id=\"result\" class=\"card hidden\" aria-live=\"polite\">
+            <h2>Ergebnis</h2>
+            <div class=\"result-grid\">
+                <div>
+                    <h3>Metadaten</h3>
+                    <div id=\"metadata-container\">
+                        <dl id=\"metadata-list\" class=\"meta\"></dl>
+                        <p id=\"metadata-empty\" class=\"muted\">Keine Metadaten vorhanden.</p>
+                    </div>
+                </div>
+                <div>
+                    <h3>Erkannte Spalten</h3>
+                    <ul id=\"column-list\" class=\"tag-list\"></ul>
+                </div>
+            </div>
+            <div class=\"table-wrapper\">
+                <table id=\"items-table\" aria-live=\"polite\">
+                    <thead></thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+            <div id=\"feedback-panel\" class=\"feedback-panel hidden\">
+                <h3>Bewerten Sie die KI-Ergebnisse</h3>
+                <p>Markieren Sie jede Zeile als <strong>korrekt</strong> oder <strong>überprüfen</strong>. Ihr Feedback verbessert die Interpretation künftiger Zeichnungen.</p>
+                <div id=\"feedback-summary\" class=\"feedback-summary\"></div>
+                <div id=\"feedback-status\" class=\"notice feedback-notice hidden\" role=\"status\" aria-live=\"polite\"></div>
+                <div class=\"feedback-controls\">
+                    <p class=\"small-note\">Bitte bewerten Sie alle angezeigten Einträge. Die Bewertung wird erst aktiviert, wenn jede Zeile markiert wurde.</p>
+                    <button id=\"feedback-submit\" type=\"button\">Feedback senden</button>
+                </div>
+            </div>
+        </section>
+
+        <footer>
+            Bereitgestellt vom integrierten FastAPI-Dienst &mdash; Endpunkt: <code>POST /extract</code>
+        </footer>
+    </main>
+
+    <script>
+        (function () {
+            const form = document.getElementById('upload-form');
+            const fileInput = document.getElementById('file');
+            const submitButton = document.getElementById('submit-button');
+            const statusBox = document.getElementById('status');
+            const resultSection = document.getElementById('result');
+            const metadataList = document.getElementById('metadata-list');
+            const metadataEmpty = document.getElementById('metadata-empty');
+            const columnList = document.getElementById('column-list');
+            const tableHead = document.querySelector('#items-table thead');
+            const tableBody = document.querySelector('#items-table tbody');
+            const feedbackPanel = document.getElementById('feedback-panel');
+            const feedbackSummaryBox = document.getElementById('feedback-summary');
+            const feedbackStatus = document.getElementById('feedback-status');
+            const feedbackButton = document.getElementById('feedback-submit');
+
+            const defaultColumns = [
+                { key: 'position', label: 'Position' },
+                { key: 'part_number', label: 'Artikelnummer' },
+                { key: 'description', label: 'Beschreibung' },
+                { key: 'quantity', label: 'Menge' },
+                { key: 'unit', label: 'Einheit' },
+                { key: 'material', label: 'Material' },
+                { key: 'comment', label: 'Kommentar' },
+                { key: 'confidence', label: 'KI-Vertrauen' }
+            ];
+
+            let currentItems = [];
+            let currentMetadata = {};
+            let feedbackSelections = new Map();
+            let sendingFeedback = false;
+
+            form.addEventListener('submit', async (event) => {
+                event.preventDefault();
+                clearNotice();
+                resultSection.classList.add('hidden');
+
+                const file = fileInput.files[0];
+                if (!file) {
+                    showNotice('Bitte wählen Sie eine PDF-Datei aus.', 'error');
+                    return;
+                }
+                if (!file.name.toLowerCase().endsWith('.pdf')) {
+                    showNotice('Die ausgewählte Datei ist keine PDF.', 'error');
+                    return;
+                }
+
+                const data = new FormData();
+                data.append('file', file);
+
+                setLoading(true);
+                showNotice('Die Datei wird analysiert …', 'info');
+
+                try {
+                    const response = await fetch('/extract', {
+                        method: 'POST',
+                        body: data
+                    });
+
+                    let payload = null;
+                    try {
+                        payload = await response.json();
+                    } catch (parseError) {
+                        payload = null;
+                    }
+
+                    if (!response.ok) {
+                        const detail = payload && payload.detail ? payload.detail : `Die Analyse ist fehlgeschlagen (Status ${response.status}).`;
+                        throw new Error(detail);
+                    }
+
+                    if (!payload || typeof payload !== 'object') {
+                        throw new Error('Unerwartetes Antwortformat.');
+                    }
+
+                    renderResult(payload);
+                    showNotice('Die Stückliste wurde erfolgreich extrahiert.', 'success');
+                } catch (error) {
+                    showNotice(error.message || 'Unbekannter Fehler bei der Analyse.', 'error');
+                } finally {
+                    setLoading(false);
+                }
+            });
+
+            tableBody.addEventListener('click', handleFeedbackClick);
+            feedbackButton.addEventListener('click', submitFeedback);
+
+            function setLoading(isLoading) {
+                submitButton.disabled = isLoading;
+                fileInput.disabled = isLoading;
+            }
+
+            function showNotice(message, kind) {
+                statusBox.textContent = '';
+                statusBox.className = 'notice ' + kind;
+                statusBox.textContent = message;
+            }
+
+            function clearNotice() {
+                statusBox.textContent = '';
+                statusBox.className = 'notice';
+            }
+
+            function renderResult(data) {
+                if (!data || typeof data !== 'object') {
+                    throw new Error('Unerwartetes Antwortformat.');
+                }
+
+                const items = Array.isArray(data.items) ? data.items : [];
+                const metadata = data.metadata && typeof data.metadata === 'object' ? data.metadata : {};
+
+                currentItems = items.map((item) => ({
+                    ...item,
+                    extras: item.extras && typeof item.extras === 'object' ? { ...item.extras } : {},
+                }));
+                currentMetadata = { ...metadata };
+                feedbackSelections = new Map();
+
+                renderMetadata(metadata);
+                renderDetectedColumns(data.detected_columns || []);
+                renderTable(currentItems);
+                prepareFeedback();
+                resultSection.classList.remove('hidden');
+            }
+
+            function renderMetadata(metadata) {
+                metadataList.innerHTML = '';
+                const entries = Object.entries(metadata || {});
+
+                if (entries.length === 0) {
+                    metadataEmpty.classList.remove('hidden');
+                    return;
+                }
+
+                metadataEmpty.classList.add('hidden');
+
+                entries.forEach(([key, value]) => {
+                    const term = document.createElement('dt');
+                    term.textContent = prettifyLabel(key);
+                    metadataList.appendChild(term);
+
+                    const detail = document.createElement('dd');
+                    detail.textContent = formatValue(value);
+                    metadataList.appendChild(detail);
+                });
+            }
+
+            function renderDetectedColumns(columns) {
+                columnList.innerHTML = '';
+
+                if (!Array.isArray(columns) || columns.length === 0) {
+                    const empty = document.createElement('li');
+                    empty.className = 'muted';
+                    empty.textContent = 'Keine Angabe';
+                    columnList.appendChild(empty);
+                    return;
+                }
+
+                columns.forEach((column) => {
+                    const item = document.createElement('li');
+                    item.textContent = prettifyLabel(column);
+                    columnList.appendChild(item);
+                });
+            }
+
+            function renderTable(items) {
+                tableHead.innerHTML = '';
+                tableBody.innerHTML = '';
+
+                if (!Array.isArray(items) || items.length === 0) {
+                    const row = document.createElement('tr');
+                    const cell = document.createElement('td');
+                    cell.colSpan = 1;
+                    cell.textContent = 'Keine Einträge gefunden.';
+                    row.appendChild(cell);
+                    tableBody.appendChild(row);
+                    feedbackPanel.classList.add('hidden');
+                    return;
+                }
+
+                const availableColumns = [];
+
+                defaultColumns.forEach((column) => {
+                    const hasValues = items.some((item) => hasValue(item[column.key]));
+                    if (hasValues) {
+                        availableColumns.push({ ...column, fromExtras: false });
+                    }
+                });
+
+                const extraKeys = new Set();
+
+                items.forEach((item) => {
+                    if (item.extras && typeof item.extras === 'object') {
+                        Object.entries(item.extras).forEach(([key, value]) => {
+                            if (hasValue(value)) {
+                                extraKeys.add(key);
+                            }
+                        });
+                    }
+
+                    Object.keys(item).forEach((key) => {
+                        if (key === 'extras') {
+                            return;
+                        }
+                        if (defaultColumns.some((column) => column.key === key)) {
+                            return;
+                        }
+                        if (hasValue(item[key])) {
+                            extraKeys.add(key);
+                        }
+                    });
+                });
+
+                Array.from(extraKeys).sort((a, b) => a.localeCompare(b, 'de')).forEach((key) => {
+                    availableColumns.push({
+                        key: key,
+                        label: prettifyLabel(key),
+                        fromExtras: !defaultColumns.some((column) => column.key === key)
+                    });
+                });
+
+                if (availableColumns.length === 0) {
+                    availableColumns.push({ key: 'description', label: 'Beschreibung', fromExtras: false });
+                }
+
+                availableColumns.push({
+                    key: '__feedback__',
+                    label: 'Bewertung',
+                    render: (_item, rowIndex) => createFeedbackCell(rowIndex),
+                });
+
+                const headerRow = document.createElement('tr');
+                availableColumns.forEach((column) => {
+                    const th = document.createElement('th');
+                    th.scope = 'col';
+                    th.textContent = column.label;
+                    headerRow.appendChild(th);
+                });
+                tableHead.appendChild(headerRow);
+
+                items.forEach((item, rowIndex) => {
+                    const row = document.createElement('tr');
+                    row.dataset.index = String(rowIndex);
+                    availableColumns.forEach((column) => {
+                        const td = document.createElement('td');
+                        if (typeof column.render === 'function') {
+                            const rendered = column.render(item, rowIndex);
+                            if (rendered instanceof Node) {
+                                td.appendChild(rendered);
+                            } else if (rendered !== undefined && rendered !== null) {
+                                td.textContent = formatValue(rendered);
+                            }
+                        } else {
+                            let value;
+                            if (
+                                column.fromExtras &&
+                                item.extras &&
+                                Object.prototype.hasOwnProperty.call(item.extras, column.key)
+                            ) {
+                                value = item.extras[column.key];
+                            } else {
+                                value = item[column.key];
+                            }
+                            if (column.key === 'confidence' && typeof value === 'number') {
+                                td.textContent = `${(value * 100).toFixed(1)} %`;
+                            } else {
+                                td.textContent = formatValue(value);
+                            }
+                        }
+                        row.appendChild(td);
+                    });
+                    tableBody.appendChild(row);
+                });
+            }
+
+            function prepareFeedback() {
+                if (!currentItems.length) {
+                    feedbackPanel.classList.add('hidden');
+                    feedbackSummaryBox.textContent = '';
+                    clearFeedbackNotice();
+                    updateFeedbackButton();
+                    return;
+                }
+
+                feedbackPanel.classList.remove('hidden');
+                clearFeedbackNotice();
+                updateFeedbackButton();
+                renderFeedbackSummary(null);
+                refreshFeedbackSummary();
+            }
+
+            function updateFeedbackButton() {
+                if (!feedbackButton) {
+                    return;
+                }
+                if (!currentItems.length) {
+                    feedbackButton.disabled = true;
+                    feedbackButton.textContent = 'Feedback senden';
+                    return;
+                }
+
+                const allRated = currentItems.every((_, index) => feedbackSelections.has(index));
+                feedbackButton.disabled = sendingFeedback || !allRated;
+                feedbackButton.textContent = sendingFeedback ? 'Wird gesendet …' : 'Feedback senden';
+            }
+
+            async function refreshFeedbackSummary() {
+                try {
+                    const response = await fetch('/feedback/summary');
+                    if (!response.ok) {
+                        throw new Error('Fehlerhafte Antwort');
+                    }
+                    const summary = await response.json();
+                    renderFeedbackSummary(summary);
+                } catch (error) {
+                    if (!feedbackSummaryBox.textContent) {
+                        feedbackSummaryBox.textContent = 'Noch keine Bewertungen vorhanden – starten Sie mit Ihrem Feedback.';
+                    }
+                }
+            }
+
+            function renderFeedbackSummary(summary) {
+                let data = summary;
+                if (data && typeof data === 'object' && data.summary && typeof data.summary === 'object') {
+                    data = data.summary;
+                }
+
+                if (!data || typeof data !== 'object') {
+                    feedbackSummaryBox.textContent = 'Noch keine Bewertungen vorhanden – starten Sie mit Ihrem Feedback.';
+                    return;
+                }
+
+                const total = Number(data.total_feedback) || 0;
+                const rate = typeof data.success_rate === 'number' ? data.success_rate : 0;
+                const percent = (rate * 100).toFixed(1);
+
+                if (total <= 0) {
+                    feedbackSummaryBox.textContent = 'Noch keine Bewertungen vorhanden – starten Sie mit Ihrem Feedback.';
+                    return;
+                }
+
+                let message = `Bisher ${total} Rückmeldungen · Übereinstimmung ${percent} %.`;
+                if (Array.isArray(data.top_features) && data.top_features.length > 0) {
+                    const highlights = data.top_features
+                        .slice(0, 2)
+                        .map((entry) => (entry && (entry.label || entry.feature)) || '')
+                        .filter(Boolean);
+                    if (highlights.length) {
+                        message += ` Häufig bestätigt: ${highlights.join(', ')}.`;
+                    }
+                }
+                feedbackSummaryBox.textContent = message;
+            }
+
+            function clearFeedbackNotice() {
+                feedbackStatus.textContent = '';
+                feedbackStatus.className = 'notice feedback-notice hidden';
+            }
+
+            function showFeedbackNotice(message, kind) {
+                feedbackStatus.textContent = message;
+                feedbackStatus.className = `notice feedback-notice ${kind}`;
+            }
+
+            function handleFeedbackClick(event) {
+                const target = event.target;
+                if (!(target instanceof HTMLElement)) {
+                    return;
+                }
+                const action = target.dataset.feedbackAction;
+                if (!action) {
+                    return;
+                }
+                const index = Number(target.dataset.index);
+                if (Number.isNaN(index)) {
+                    return;
+                }
+                setRowFeedback(index, action === 'approve');
+            }
+
+            function setRowFeedback(index, correct) {
+                feedbackSelections.set(index, correct);
+                updateRowFeedbackUI(index);
+                clearFeedbackNotice();
+                updateFeedbackButton();
+            }
+
+            function updateRowFeedbackUI(index) {
+                const row = tableBody.querySelector(`tr[data-index="${index}"]`);
+                if (!row) {
+                    return;
+                }
+                const selection = feedbackSelections.get(index);
+                row.querySelectorAll('.feedback-button').forEach((button) => {
+                    const action = button.dataset.feedbackAction;
+                    if (action === 'approve') {
+                        if (selection === true) {
+                            button.classList.add('is-active');
+                        } else {
+                            button.classList.remove('is-active');
+                        }
+                    } else if (action === 'reject') {
+                        button.classList.add('reject');
+                        if (selection === false) {
+                            button.classList.add('is-active');
+                        } else {
+                            button.classList.remove('is-active');
+                        }
+                    }
+                });
+            }
+
+            function createFeedbackCell(rowIndex) {
+                const wrapper = document.createElement('div');
+                wrapper.className = 'feedback-actions';
+
+                const approveButton = document.createElement('button');
+                approveButton.type = 'button';
+                approveButton.className = 'feedback-button approve';
+                approveButton.dataset.feedbackAction = 'approve';
+                approveButton.dataset.index = String(rowIndex);
+                approveButton.textContent = '✅ Korrekt';
+                approveButton.title = 'Eintrag als korrekt markieren';
+
+                const rejectButton = document.createElement('button');
+                rejectButton.type = 'button';
+                rejectButton.className = 'feedback-button reject';
+                rejectButton.dataset.feedbackAction = 'reject';
+                rejectButton.dataset.index = String(rowIndex);
+                rejectButton.textContent = '❌ Prüfen';
+                rejectButton.title = 'Eintrag zur Überprüfung markieren';
+
+                wrapper.appendChild(approveButton);
+                wrapper.appendChild(rejectButton);
+                return wrapper;
+            }
+
+            async function submitFeedback() {
+                if (feedbackButton.disabled || sendingFeedback) {
+                    return;
+                }
+
+                const ratings = Array.from(feedbackSelections.entries()).map(([index, correct]) => ({
+                    item: currentItems[index],
+                    correct,
+                }));
+
+                if (ratings.length !== currentItems.length) {
+                    showFeedbackNotice('Bitte bewerten Sie alle Einträge, bevor Sie das Feedback senden.', 'error');
+                    return;
+                }
+
+                sendingFeedback = true;
+                updateFeedbackButton();
+                showFeedbackNotice('Feedback wird übertragen …', 'info');
+
+                const payload = {
+                    document: currentMetadata && currentMetadata.source ? currentMetadata.source : null,
+                    ratings,
+                    metadata: currentMetadata,
+                };
+
+                try {
+                    const response = await fetch('/feedback', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify(payload),
+                    });
+                    const summary = await response.json().catch(() => null);
+                    if (!response.ok) {
+                        const detail = summary && summary.detail ? summary.detail : 'Feedback konnte nicht gespeichert werden.';
+                        throw new Error(detail);
+                    }
+                    showFeedbackNotice('Vielen Dank für Ihr Feedback!', 'success');
+                    renderFeedbackSummary(summary);
+                    refreshFeedbackSummary();
+                } catch (error) {
+                    showFeedbackNotice(error.message || 'Feedback konnte nicht übermittelt werden.', 'error');
+                } finally {
+                    sendingFeedback = false;
+                    updateFeedbackButton();
+                }
+            }
+
+            function prettifyLabel(label) {
+                return String(label)
+                    .replace(/_/g, ' ')
+                    .replace(/\b\w/g, (char) => char.toUpperCase());
+            }
+
+            function hasValue(value) {
+                if (value === null || value === undefined) {
+                    return false;
+                }
+                if (typeof value === 'number') {
+                    return true;
+                }
+                if (Array.isArray(value)) {
+                    return value.length > 0;
+                }
+                if (typeof value === 'string') {
+                    return value.trim() !== '';
+                }
+                return true;
+            }
+
+            function formatValue(value) {
+                if (value === null || value === undefined) {
+                    return '';
+                }
+                if (Array.isArray(value)) {
+                    return value.map((entry) => formatValue(entry)).join(', ');
+                }
+                if (typeof value === 'number') {
+                    return value.toLocaleString('de-DE');
+                }
+                return String(value);
+            }
+        })();
+    </script>
+</body>
+</html>
+"""
+
+
+__all__ = ["WEB_INTERFACE_HTML"]

--- a/bom_extractor/__init__.py
+++ b/bom_extractor/__init__.py
@@ -1,0 +1,20 @@
+"""Utilities for extracting bills of materials (Stücklisten) from PDF drawings."""
+
+from .extractor import (
+    BOMExtractionError,
+    BOMExtractionResult,
+    BOMItem,
+    extract_bom_from_bytes,
+    extract_bom_from_pdf,
+)
+from .learning import LearningEngine, get_learning_engine
+
+__all__ = [
+    "BOMItem",
+    "BOMExtractionResult",
+    "BOMExtractionError",
+    "extract_bom_from_pdf",
+    "extract_bom_from_bytes",
+    "LearningEngine",
+    "get_learning_engine",
+]

--- a/bom_extractor/extractor.py
+++ b/bom_extractor/extractor.py
@@ -1,0 +1,1137 @@
+"""Core logic for extracting bills of materials from PDF engineering drawings."""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+import io
+import re
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+
+import pdfplumber
+
+from .learning import apply_learning_to_result
+
+__all__ = [
+    "BOMItem",
+    "BOMExtractionResult",
+    "BOMExtractionError",
+    "extract_bom_from_pdf",
+    "extract_bom_from_bytes",
+]
+
+
+TABLE_SETTINGS: Sequence[Dict[str, Union[str, float]]] = (
+    {"vertical_strategy": "lines", "horizontal_strategy": "lines"},
+    {"vertical_strategy": "text", "horizontal_strategy": "text"},
+    {"vertical_strategy": "lines", "horizontal_strategy": "text"},
+)
+
+POINT_TO_MM = 25.4 / 72.0
+
+CALLOUT_PATTERN = re.compile(
+    r"""
+    ^\s*
+    (?:[-•\u2022]\s*)?
+    (?:(?P<label>(?:pos(?:ition)?|item|nr|no\.?|\#)\s*)?(?P<position>\d{1,3}[A-Za-z]?))
+    (?:\s*[\.:)\-])?
+    \s+
+    (?P<rest>.+)
+    $
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+ALT_CALLOUT_PATTERN = re.compile(
+    r"^(?P<position>[A-Za-z]\d{1,3})\s*[:\-]\s*(?P<rest>.+)$"
+)
+
+SIMPLE_ENUM_PATTERN = re.compile(r"^(?P<position>\d{1,3})\s+(?P<rest>.+)$")
+
+ITEM_KEYWORDS = (
+    "qty",
+    "quantity",
+    "anzahl",
+    "menge",
+    "stk",
+    "stück",
+    "st",
+    "pcs",
+    "pieces",
+    "x",
+    "off",
+    "ea",
+)
+
+SHAPE_LABELS = {
+    "rectangle": "Rechteck",
+    "curve": "Kontur",
+    "circle": "Kreis",
+}
+
+COMPONENT_LABELS = {
+    "rohrende": "Rohrende",
+    "rohr": "Rohr",
+    "rohrbogen": "Rohrbogen",
+    "blech": "Blech",
+    "flansch": "Flansch",
+}
+
+_COMPONENT_KEYWORD_GROUPS: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
+    (
+        "rohrende",
+        (
+            r"rohr\s*ende",
+            r"rohrende",
+            r"endkappe",
+            r"pipe\s*cap",
+            r"end\s*cap",
+        ),
+    ),
+    (
+        "rohrbogen",
+        (
+            r"rohr\s*bog",
+            r"rohrbogen",
+            r"bogen\s*90",
+            r"bogen\s*45",
+            r"bogen",
+            r"elbow",
+            r"bend",
+        ),
+    ),
+    (
+        "flansch",
+        (
+            r"flansch",
+            r"flange",
+        ),
+    ),
+    (
+        "blech",
+        (
+            r"blech",
+            r"platte",
+            r"blechplatte",
+            r"sheet",
+            r"plate",
+        ),
+    ),
+    (
+        "rohr",
+        (
+            r"\brohr\b",
+            r"pipe",
+            r"tube",
+            r"leitung",
+        ),
+    ),
+)
+
+COMPONENT_PATTERNS: Tuple[Tuple[str, Tuple[re.Pattern, ...]], ...] = tuple(
+    (code, tuple(re.compile(pattern, re.IGNORECASE) for pattern in patterns))
+    for code, patterns in _COMPONENT_KEYWORD_GROUPS
+)
+
+
+HEADER_ALIASES: Dict[str, Tuple[str, ...]] = {
+    "position": (
+        "position",
+        "pos",
+        "pos.",
+        "item",
+        "itemno",
+        "item no",
+        "item no.",
+        "no",
+        "nr",
+        "index",
+    ),
+    "part_number": (
+        "part",
+        "partno",
+        "part no",
+        "part-number",
+        "article",
+        "artikel",
+        "artnr",
+        "art.nr",
+        "drawing",
+        "drawing no",
+        "zeichnungs",
+        "zeichnungsnr",
+        "zeichnung",
+        "bestell",
+        "order",
+        "item code",
+        "teilenummer",
+    ),
+    "description": (
+        "description",
+        "descr",
+        "desc",
+        "bezeichnung",
+        "benennung",
+        "designation",
+        "title",
+        "titel",
+        "beschreibung",
+    ),
+    "quantity": (
+        "qty",
+        "qty.",
+        "quantity",
+        "menge",
+        "anzahl",
+        "stück",
+        "stückzahl",
+        "stk",
+        "st",
+        "pcs",
+        "qty/qty",
+    ),
+    "unit": (
+        "unit",
+        "einheit",
+        "uom",
+        "ein",
+        "maßeinheit",
+    ),
+    "material": (
+        "material",
+        "werkstoff",
+        "mat",
+    ),
+    "comment": (
+        "comment",
+        "comments",
+        "bemerkung",
+        "bemerkungen",
+        "note",
+        "notes",
+        "remark",
+        "remarks",
+    ),
+}
+
+HEADER_ALIAS_LOOKUP: Dict[str, str] = {}
+for canonical, aliases in HEADER_ALIASES.items():
+    for alias in aliases:
+        normalised_alias = re.sub(r"[^a-z0-9]+", "", alias.lower())
+        HEADER_ALIAS_LOOKUP.setdefault(normalised_alias, canonical)
+
+# Regular expression used to detect numbers (supporting comma as decimal separator)
+QUANTITY_RE = re.compile(
+    r"(?P<value>-?\d+(?:[\.,]\d+)?)\s*(?P<unit>[a-zA-Z%\u00b0\/]*)"
+)
+
+
+class BOMExtractionError(RuntimeError):
+    """Raised when the extractor cannot locate a valid bill of materials table."""
+
+
+@dataclass
+class BOMItem:
+    """Container for a single bill of materials entry."""
+
+    position: Optional[str] = None
+    part_number: Optional[str] = None
+    description: Optional[str] = None
+    quantity: Optional[Union[int, float]] = None
+    unit: Optional[str] = None
+    material: Optional[str] = None
+    comment: Optional[str] = None
+    confidence: Optional[float] = None
+    extras: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Union[str, int, float, Dict[str, str], None]]:
+        """Convert the item into a serialisable dictionary."""
+
+        data = {
+            "position": self.position,
+            "part_number": self.part_number,
+            "description": self.description,
+            "quantity": self.quantity,
+            "unit": self.unit,
+            "material": self.material,
+            "comment": self.comment,
+            "confidence": self.confidence,
+            "extras": {k: v for k, v in self.extras.items() if v},
+        }
+        return {k: v for k, v in data.items() if v is not None and (v != {} or k == "extras")}
+
+
+@dataclass
+class BOMExtractionResult:
+    """Represents a complete bill of materials extracted from a drawing."""
+
+    items: List[BOMItem]
+    detected_columns: List[str]
+    metadata: Dict[str, Union[str, List[int], int]] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "items": [item.to_dict() for item in self.items],
+            "detected_columns": self.detected_columns,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class _TableCandidate:
+    counter: Counter[str]
+    counter_total: int
+    items: List[BOMItem]
+    columns: List[str]
+    score: Tuple[int, int]
+    pages: Set[int]
+
+
+def extract_bom_from_pdf(path: Union[str, io.BytesIO]) -> BOMExtractionResult:
+    """Extract a bill of materials from a PDF file located at *path*."""
+
+    with pdfplumber.open(path) as pdf:
+        return _extract_from_pdf_document(pdf, source=getattr(path, "name", str(path)))
+
+
+def extract_bom_from_bytes(content: bytes, source: Optional[str] = None) -> BOMExtractionResult:
+    """Extract a bill of materials from in-memory PDF data."""
+
+    buffer = io.BytesIO(content)
+    buffer.name = source or "<memory>"
+    with pdfplumber.open(buffer) as pdf:
+        return _extract_from_pdf_document(pdf, source=buffer.name)
+
+
+def _extract_from_pdf_document(pdf: pdfplumber.PDF, source: Optional[str]) -> BOMExtractionResult:
+    items: List[BOMItem] = []
+    detected_columns: List[str] = []
+    pages_used: List[int] = []
+    tables_seen = 0
+    table_candidates: List[_TableCandidate] = []
+
+    for page_index, page in enumerate(pdf.pages, start=1):
+        for table in _iter_tables(page):
+            tables_seen += 1
+            counter = _table_counter_signature(table)
+            if not counter:
+                continue
+            table_items, columns = _process_table(table)
+            if not table_items:
+                continue
+            score = (len(columns), len(table_items))
+            counter_total = sum(counter.values())
+            pages: Set[int] = {page_index}
+            skip_candidate = False
+            new_candidates: List[_TableCandidate] = []
+
+            for candidate in table_candidates:
+                if counter >= candidate.counter and (
+                    score > candidate.score
+                    or (score == candidate.score and counter_total > candidate.counter_total)
+                ):
+                    pages.update(candidate.pages)
+                    continue
+
+                if candidate.counter >= counter and (
+                    candidate.score > score
+                    or (candidate.score == score and candidate.counter_total >= counter_total)
+                ):
+                    candidate.pages.add(page_index)
+                    skip_candidate = True
+
+                new_candidates.append(candidate)
+
+            if skip_candidate:
+                table_candidates = new_candidates
+                continue
+
+            new_candidates.append(
+                _TableCandidate(
+                    counter=counter,
+                    counter_total=counter_total,
+                    items=table_items,
+                    columns=columns,
+                    score=score,
+                    pages=pages,
+                )
+            )
+            table_candidates = new_candidates
+
+    for candidate in table_candidates:
+        items.extend(candidate.items)
+        pages_used.extend(candidate.pages)
+        for col in candidate.columns:
+            if col not in detected_columns:
+                detected_columns.append(col)
+
+    if not items:
+        fallback_items, fallback_columns, fallback_metadata = _interpret_without_table(pdf)
+        metadata: Dict[str, Union[str, List[int], int]] = {
+            "source": source or "<unknown>",
+            "tables_checked": tables_seen,
+        }
+        metadata.update(fallback_metadata)
+        metadata.setdefault("pages", [])
+        return apply_learning_to_result(
+            BOMExtractionResult(
+                items=fallback_items,
+                detected_columns=fallback_columns,
+                metadata=metadata,
+            )
+        )
+
+    metadata = {
+        "source": source or "<unknown>",
+        "pages": sorted(set(pages_used)),
+        "tables_checked": tables_seen,
+        "mode": "table",
+    }
+
+    return apply_learning_to_result(
+        BOMExtractionResult(
+            items=items,
+            detected_columns=sorted(set(detected_columns)),
+            metadata=metadata,
+        )
+    )
+
+
+def _iter_tables(page: pdfplumber.page.Page) -> Iterable[List[List[Optional[str]]]]:
+    """Yield tables extracted from a PDF page using different detection strategies."""
+
+    seen_signatures: Set[Tuple[Tuple[Optional[str], ...], ...]] = set()
+    for settings in TABLE_SETTINGS:
+        try:
+            tables = page.extract_tables(table_settings=settings)
+        except NotImplementedError:
+            continue
+        if not tables:
+            continue
+        for table in tables:
+            # Avoid returning duplicate tables produced by different strategies.
+            signature = tuple(
+                tuple(row) if isinstance(row, (list, tuple)) else (row,)
+                for row in table
+            )
+            if signature in seen_signatures:
+                continue
+            seen_signatures.add(signature)
+            yield table
+
+
+def _process_table(raw_table: Sequence[Sequence[Optional[str]]]) -> Tuple[List[BOMItem], List[str]]:
+    """Attempt to interpret a raw table as a bill of materials."""
+
+    cleaned_table: List[List[str]] = []
+    for row in raw_table:
+        cleaned_row = _clean_row(row)
+        if any(cleaned_row):
+            cleaned_table.append(cleaned_row)
+    if not cleaned_table:
+        return [], []
+
+    header_index, header_map, header_names = _find_header_row(cleaned_table)
+    if header_index is None:
+        return [], []
+
+    data_rows = cleaned_table[header_index + 1 :]
+    if not data_rows:
+        return [], []
+
+    items: List[BOMItem] = []
+    for row in data_rows:
+        item = _row_to_item(row, header_map, header_names)
+        if item:
+            items.append(item)
+
+    normalized_columns = sorted(set(header_map.values()))
+    return items, normalized_columns
+
+
+def _clean_row(row: Sequence[Optional[str]]) -> List[str]:
+    return [_normalise_cell(cell) for cell in row]
+
+
+def _normalise_cell(cell: Optional[str]) -> str:
+    if cell is None:
+        return ""
+    text = str(cell)
+    text = text.replace("\n", " ")
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _table_counter_signature(
+    raw_table: Sequence[Sequence[Optional[str]]],
+) -> Counter[str]:
+    counter: Counter[str] = Counter()
+    for row in raw_table:
+        if not row:
+            continue
+        for cell in row:
+            value = _normalise_cell(cell)
+            if value:
+                counter[value] += 1
+    return counter
+
+
+def _find_header_row(table: Sequence[Sequence[str]]) -> Tuple[Optional[int], Dict[int, str], Dict[int, str]]:
+    """Locate the header row within a table and return column mappings."""
+
+    best_index: Optional[int] = None
+    best_map: Dict[int, str] = {}
+    best_header_names: Dict[int, str] = {}
+    best_score = 0
+
+    for idx, row in enumerate(table):
+        mapping: Dict[int, str] = {}
+        names: Dict[int, str] = {}
+        score = 0
+
+        for col_index, cell in enumerate(row):
+            if not cell:
+                continue
+            normalised = _normalise_header(cell)
+            if not normalised:
+                continue
+            match = _match_header(normalised)
+            names[col_index] = normalised
+            if match and match not in mapping.values():
+                mapping[col_index] = match
+                score += 1
+
+        # Require at least two recognised columns for a confident BOM header.
+        if score >= 2 and score > best_score:
+            best_index = idx
+            best_map = mapping
+            best_header_names = names
+            best_score = score
+
+    return best_index, best_map, best_header_names
+
+
+def _normalise_header(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _match_header(value: str) -> Optional[str]:
+    return HEADER_ALIAS_LOOKUP.get(value)
+
+
+def _detect_component_from_text(*texts: Optional[str]) -> Optional[str]:
+    """Return the canonical component code if any of *texts* matches known keywords."""
+
+    for text in texts:
+        if not text:
+            continue
+        lowered = text.lower()
+        for code, patterns in COMPONENT_PATTERNS:
+            for pattern in patterns:
+                if pattern.search(lowered):
+                    return code
+    return None
+
+
+def _annotate_item_component(
+    item: BOMItem,
+    *,
+    preset: Optional[str] = None,
+    source: Optional[str] = None,
+) -> BOMItem:
+    """Augment *item* with component metadata derived from text or heuristics."""
+
+    component = preset or _detect_component_from_text(
+        item.description,
+        item.part_number,
+        item.comment,
+        " ".join(str(value) for value in item.extras.values()) if item.extras else None,
+    )
+    if not component:
+        return item
+
+    label = COMPONENT_LABELS.get(component, component.title())
+    item.extras["component_type"] = label
+    item.extras.setdefault("component_code", component)
+
+    if source:
+        item.extras.setdefault("component_source", source)
+    elif preset:
+        item.extras.setdefault("component_source", "heuristik")
+    else:
+        item.extras.setdefault("component_source", "text")
+
+    if not item.description:
+        item.description = label
+
+    return item
+
+
+def _row_to_item(row: Sequence[str], header_map: Dict[int, str], header_names: Dict[int, str]) -> Optional[BOMItem]:
+    recognised: Dict[str, str] = {}
+    extras: Dict[str, str] = {}
+
+    for idx, cell in enumerate(row):
+        if not cell:
+            continue
+        if idx in header_map:
+            recognised[header_map[idx]] = cell
+        else:
+            header_name = header_names.get(idx, f"column_{idx}")
+            extras[header_name] = cell
+
+    if not recognised and not extras:
+        return None
+
+    quantity_value: Optional[Union[int, float]] = None
+    unit_value: Optional[str] = None
+    if "quantity" in recognised:
+        quantity_value, unit_value = _parse_quantity(recognised.get("quantity"))
+
+    # If the unit column exists separately, it has precedence
+    if "unit" in recognised and recognised["unit"]:
+        unit_value = recognised["unit"]
+
+    item = BOMItem(
+        position=recognised.get("position"),
+        part_number=recognised.get("part_number"),
+        description=recognised.get("description"),
+        quantity=quantity_value,
+        unit=unit_value,
+        material=recognised.get("material"),
+        comment=recognised.get("comment"),
+        extras=extras,
+    )
+
+    # If a recognised field still contains data that should be treated as extra (e.g. quantity without value)
+    # we keep the original text in extras for traceability.
+    for key, value in recognised.items():
+        if key not in {"position", "part_number", "description", "quantity", "unit", "material", "comment"}:
+            item.extras[key] = value
+
+    item.extras.setdefault("source", "table")
+
+    # If we failed to parse a numeric quantity keep the raw text inside extras.
+    if "quantity" in recognised and quantity_value is None:
+        item.extras.setdefault("quantity_raw", recognised["quantity"])
+
+    return _annotate_item_component(item)
+
+
+def _parse_quantity(value: Optional[str]) -> Tuple[Optional[Union[int, float]], Optional[str]]:
+    if not value:
+        return None, None
+
+    match = QUANTITY_RE.search(value)
+    if not match:
+        return None, None
+
+    raw_value = match.group("value").replace(",", ".")
+    try:
+        numeric = float(raw_value)
+    except ValueError:
+        return None, match.group("unit") or None
+
+    if numeric.is_integer():
+        numeric_value: Union[int, float] = int(numeric)
+    else:
+        numeric_value = numeric
+
+    unit = match.group("unit") or None
+    return numeric_value, unit
+
+
+def _interpret_without_table(
+    pdf: pdfplumber.PDF,
+) -> Tuple[List[BOMItem], List[str], Dict[str, Union[str, List[int], int]]]:
+    """Create a synthetic BOM by interpreting annotations and geometry."""
+
+    used_positions: Set[str] = set()
+    text_items, used_positions, next_position, text_meta = _interpret_textual_annotations(
+        pdf, used_positions=used_positions, start_position=1
+    )
+    geometry_items, used_positions, next_position, geometry_meta = _interpret_geometry_components(
+        pdf, used_positions=used_positions, start_position=next_position
+    )
+
+    items = text_items + geometry_items
+    metadata: Dict[str, Union[str, List[int], int]] = {
+        "mode": "interpreted",
+        "annotation_items": len(text_items),
+        "geometry_items": len(geometry_items),
+        "lines_checked": text_meta.get("lines_checked", 0),
+        "shapes_considered": geometry_meta.get("shapes_considered", 0),
+    }
+
+    pages = sorted(set(text_meta.get("pages", [])) | set(geometry_meta.get("pages", [])))
+    if pages:
+        metadata["pages"] = pages
+
+    if not items:
+        placeholder_position = "1"
+        if placeholder_position in used_positions:
+            placeholder_position, _ = _allocate_position(used_positions, next_position)
+        else:
+            used_positions.add(placeholder_position)
+        placeholder = BOMItem(
+            position=placeholder_position,
+            description="Automatisch generierte Sammelposition",
+            quantity=1,
+            unit="assembly",
+            comment="Keine interpretierbaren Komponenten gefunden – bitte Zeichnung prüfen.",
+            extras={"source": "fallback", "confidence": "sehr gering"},
+        )
+        items.append(placeholder)
+        metadata["fallback_placeholder"] = 1
+
+    detected_columns = _infer_detected_columns(items)
+    return items, detected_columns, metadata
+
+
+def _interpret_textual_annotations(
+    pdf: pdfplumber.PDF,
+    *,
+    used_positions: Optional[Set[str]] = None,
+    start_position: int = 1,
+) -> Tuple[List[BOMItem], Set[str], int, Dict[str, Union[List[int], int]]]:
+    """Derive BOM entries from free-text annotations and callouts."""
+
+    if used_positions is None:
+        used_positions = set()
+
+    items: List[BOMItem] = []
+    pages_with_items: Set[int] = set()
+    lines_checked = 0
+    next_position = max(start_position, 1)
+
+    for page_index, page in enumerate(pdf.pages, start=1):
+        try:
+            raw_text = page.extract_text(x_tolerance=2, y_tolerance=2)
+        except TypeError:
+            raw_text = page.extract_text()
+        if not raw_text:
+            continue
+
+        for raw_line in raw_text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            lines_checked += 1
+            parsed = _interpret_annotation_line(line)
+            if not parsed:
+                continue
+
+            extras = parsed.get("extras") or {}
+            position = parsed.get("position")
+            if position:
+                position = str(position)
+                if position in used_positions:
+                    extras.setdefault(
+                        "note", "Position mehrfach erkannt, automatisch neu nummeriert"
+                    )
+                    position, next_position = _allocate_position(used_positions, next_position)
+                else:
+                    used_positions.add(position)
+                    if position.isdigit():
+                        next_position = max(next_position, int(position) + 1)
+            else:
+                position, next_position = _allocate_position(used_positions, next_position)
+
+            extras.setdefault("source", "text")
+
+            item = BOMItem(
+                position=position,
+                part_number=parsed.get("part_number"),
+                description=parsed.get("description"),
+                quantity=parsed.get("quantity"),
+                unit=parsed.get("unit"),
+                comment=parsed.get("comment"),
+                extras={key: str(value) for key, value in extras.items() if value},
+            )
+            item = _annotate_item_component(item)
+            items.append(item)
+            pages_with_items.add(page_index)
+
+    metadata: Dict[str, Union[List[int], int]] = {
+        "pages": sorted(pages_with_items),
+        "lines_checked": lines_checked,
+    }
+    return items, used_positions, next_position, metadata
+
+
+def _interpret_annotation_line(line: str) -> Optional[Dict[str, object]]:
+    """Parse a single textual annotation into structured BOM attributes."""
+
+    text = line.strip()
+    if not text:
+        return None
+
+    text = text.strip("-•\u2022 ")
+    if not text:
+        return None
+
+    position, rest = _extract_position_and_rest(text)
+    if rest is None:
+        return None
+    if position is None and not _line_looks_like_item(rest):
+        return None
+
+    quantity, unit, remainder = _extract_quantity_from_text(rest)
+    remainder, comment = _extract_comment(remainder)
+    part_number, description = _extract_part_number_and_description(remainder)
+
+    if not description and not part_number:
+        return None
+
+    extras: Dict[str, str] = {"source": "text", "raw": line.strip()}
+    score = 0
+    if position:
+        score += 1
+    if part_number:
+        score += 1
+    if quantity is not None:
+        score += 1
+    if description:
+        score += 1
+    if score >= 3:
+        extras["confidence"] = "hoch"
+    elif score >= 2:
+        extras["confidence"] = "mittel"
+    else:
+        extras["confidence"] = "niedrig"
+
+    return {
+        "position": position,
+        "part_number": part_number,
+        "description": description or part_number,
+        "quantity": quantity,
+        "unit": unit,
+        "comment": comment,
+        "extras": extras,
+    }
+
+
+def _extract_position_and_rest(text: str) -> Tuple[Optional[str], Optional[str]]:
+    for pattern in (CALLOUT_PATTERN, ALT_CALLOUT_PATTERN, SIMPLE_ENUM_PATTERN):
+        match = pattern.match(text)
+        if not match:
+            continue
+        rest = match.group("rest") if "rest" in match.groupdict() else None
+        if rest:
+            rest = rest.strip()
+        if not rest or not re.search(r"[A-Za-z]", rest):
+            continue
+        return match.group("position"), rest
+
+    if re.search(r"[A-Za-z]", text):
+        return None, text.strip()
+    return None, None
+
+
+def _extract_quantity_from_text(text: str) -> Tuple[Optional[Union[int, float]], Optional[str], str]:
+    if not text:
+        return None, None, ""
+
+    matches = list(QUANTITY_RE.finditer(text))
+    chosen_match = None
+    for match in reversed(matches):
+        start, end = match.span()
+        prefix = text[max(0, start - 6) : start].lower()
+        suffix = text[end : min(len(text), end + 6)].lower()
+        if any(keyword in prefix for keyword in ITEM_KEYWORDS) or any(
+            keyword in suffix for keyword in ITEM_KEYWORDS
+        ):
+            chosen_match = match
+            break
+        if (start > 0 and text[start - 1] == "(") or (end < len(text) and text[end : end + 1] == ")"):
+            chosen_match = match
+            break
+
+    if not chosen_match and len(matches) == 1:
+        match = matches[0]
+        if re.search(r"[A-Za-z]", text[: match.start()]) or re.search(
+            r"(qty|pcs|stk|x)", text[match.end() :].lower()
+        ):
+            chosen_match = match
+
+    if not chosen_match:
+        return None, None, text
+
+    quantity_value, unit_value = _parse_quantity(chosen_match.group(0))
+    if unit_value and unit_value.lower() == "x":
+        unit_value = "pcs"
+
+    start, end = chosen_match.span()
+    before = text[:start]
+    after = text[end:]
+    if before.endswith("(") and after.startswith(")"):
+        before = before[:-1]
+        after = after[1:]
+    cleaned = f"{before} {after}".strip()
+    cleaned = re.sub(
+        r"\b(?:qty|quantity|menge|anzahl|stk|stück|st|pcs|pieces|ea|off)\b",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip(" -:;,")
+
+    return quantity_value, unit_value, cleaned
+
+
+def _extract_comment(text: str) -> Tuple[str, Optional[str]]:
+    if not text:
+        return "", None
+
+    comment_match = re.search(r"\(([^)]+)\)\s*$", text)
+    if not comment_match:
+        return text.strip(), None
+
+    comment = comment_match.group(1).strip()
+    cleaned = text[: comment_match.start()].strip()
+    return cleaned, comment or None
+
+
+def _extract_part_number_and_description(text: str) -> Tuple[Optional[str], str]:
+    working = text.strip(" -:;,")
+    if not working:
+        return None, ""
+
+    for separator in (" - ", " – ", " — ", ":"):
+        if separator in working:
+            left, right = working.split(separator, 1)
+            left = left.strip(" -:;,")
+            right = right.strip(" -:;,")
+            if _looks_like_part_number(left) and right:
+                return left, right
+            if _looks_like_part_number(right) and left:
+                return right, left
+
+    tokens = working.split()
+    part_index: Optional[int] = None
+    part_number: Optional[str] = None
+    for idx, token in enumerate(tokens):
+        cleaned = token.strip(",;:/()[]")
+        if _looks_like_part_number(cleaned):
+            part_index = idx
+            part_number = cleaned
+            break
+
+    description_tokens = [token for i, token in enumerate(tokens) if i != part_index]
+    description = " ".join(description_tokens).strip(" -:;,")
+    description = re.sub(r"\s{2,}", " ", description)
+
+    return part_number, description
+
+
+def _looks_like_part_number(token: str) -> bool:
+    candidate = token.strip()
+    if not candidate or len(candidate) < 2:
+        return False
+
+    lowered = candidate.lower()
+    for unit_suffix in ("mm", "cm", "m", "kg", "g", "nm"):
+        if lowered.endswith(unit_suffix) and candidate[:- len(unit_suffix)].isdigit():
+            return False
+
+    has_digit = any(ch.isdigit() for ch in candidate)
+    has_alpha = any(ch.isalpha() for ch in candidate)
+    if has_digit and has_alpha:
+        return True
+    if has_digit and any(sep in candidate for sep in "-_/."):
+        return True
+    if candidate.replace("-", "").isdigit() and "-" in candidate and len(candidate) >= 4:
+        return True
+    if candidate.isdigit() and len(candidate) >= 4:
+        return True
+    return False
+
+
+def _line_looks_like_item(text: str) -> bool:
+    lowered = text.lower()
+    if any(keyword in lowered for keyword in ITEM_KEYWORDS):
+        return True
+    if re.search(r"\b\d+\s*(?:x|pcs|stk|st|off|ea)\b", lowered):
+        return True
+    if re.search(r"\b[a-z]+\b", lowered) and re.search(r"\d", text):
+        return True
+    if re.search(r"[A-Za-z]+-[A-Za-z0-9]+", text):
+        return True
+    return False
+
+
+def _interpret_geometry_components(
+    pdf: pdfplumber.PDF,
+    *,
+    used_positions: Set[str],
+    start_position: int,
+) -> Tuple[List[BOMItem], Set[str], int, Dict[str, Union[List[int], int]]]:
+    """Cluster geometric primitives into pseudo BOM entries."""
+
+    shapes: Dict[Tuple[str, float, float, Optional[str]], Dict[str, object]] = {}
+    pages_with_shapes: Set[int] = set()
+    shapes_considered = 0
+    next_position = max(start_position, 1)
+
+    for page_index, page in enumerate(pdf.pages, start=1):
+        page_width = getattr(page, "width", None)
+        page_height = getattr(page, "height", None)
+
+        for rect in getattr(page, "rects", []):
+            width = float(rect.get("width", 0))
+            height = float(rect.get("height", 0))
+            if min(width, height) < 10:
+                continue
+            if page_width and page_height:
+                if (
+                    width >= page_width * 0.9
+                    or height >= page_height * 0.9
+                    or rect.get("x0", 0) <= 2
+                    or rect.get("y0", 0) <= 2
+                    or rect.get("x1", 0) >= page_width - 2
+                    or rect.get("y1", 0) >= page_height - 2
+                ):
+                    continue
+
+            major, minor = _shape_dimension_key(width, height)
+            component, _ = _classify_shape_component("rectangle", major, minor)
+            key = ("rectangle", major, minor, component)
+            bucket = shapes.setdefault(key, {"count": 0, "pages": set()})
+            bucket["count"] += 1
+            bucket["pages"].add(page_index)
+            pages_with_shapes.add(page_index)
+            shapes_considered += 1
+
+        for curve in getattr(page, "curves", []):
+            points = curve.get("points") or curve.get("pts") or []
+            coords: List[Tuple[float, float]] = []
+            for point in points:
+                if isinstance(point, (tuple, list)) and len(point) >= 2:
+                    coords.append((float(point[0]), float(point[1])))
+                elif isinstance(point, dict) and {"x", "y"} <= set(point.keys()):
+                    coords.append((float(point["x"]), float(point["y"])))
+            if len(coords) < 2:
+                continue
+
+            xs = [pt[0] for pt in coords]
+            ys = [pt[1] for pt in coords]
+            width = max(xs) - min(xs)
+            height = max(ys) - min(ys)
+            if max(width, height) < 10:
+                continue
+            if page_width and page_height:
+                if width >= page_width * 0.9 or height >= page_height * 0.9:
+                    continue
+
+            shape_type = "circle" if abs(width - height) <= 5 else "curve"
+            major, minor = _shape_dimension_key(width, height)
+            component, _ = _classify_shape_component(shape_type, major, minor)
+            key = (shape_type, major, minor, component)
+            bucket = shapes.setdefault(key, {"count": 0, "pages": set()})
+            bucket["count"] += 1
+            bucket["pages"].add(page_index)
+            pages_with_shapes.add(page_index)
+            shapes_considered += 1
+
+    items: List[BOMItem] = []
+    for shape_key in sorted(
+        shapes.keys(), key=lambda key: (key[0], key[1], key[2], key[3] or "")
+    ):
+        shape_type, major, minor, component = shape_key
+        data = shapes[shape_key]
+        position, next_position = _allocate_position(used_positions, next_position)
+        component_description = None
+        if component:
+            _, component_description = _classify_shape_component(shape_type, major, minor)
+        description = component_description or _format_shape_description(shape_type, major, minor)
+        extras = {
+            "source": "geometry",
+            "shape": SHAPE_LABELS.get(shape_type, shape_type),
+            "pages": ",".join(str(page) for page in sorted(data["pages"])),
+        }
+        if component:
+            extras["component_type"] = COMPONENT_LABELS.get(component, component.title())
+            extras.setdefault("component_source", "geometry")
+        item = BOMItem(
+            position=position,
+            description=description,
+            quantity=int(data["count"]),
+            unit="pcs",
+            extras=extras,
+        )
+        item = _annotate_item_component(item, preset=component, source="geometry")
+        items.append(item)
+
+    metadata: Dict[str, Union[List[int], int]] = {
+        "pages": sorted(pages_with_shapes),
+        "shapes_considered": shapes_considered,
+    }
+    return items, used_positions, next_position, metadata
+
+
+def _shape_dimension_key(width: float, height: float) -> Tuple[float, float]:
+    major = _round_mm(max(width, height))
+    minor = _round_mm(min(width, height))
+    return major, minor
+
+
+def _round_mm(value: float) -> float:
+    return round(value * POINT_TO_MM, 1)
+
+
+def _format_shape_description(shape_type: str, major: float, minor: float) -> str:
+    label = SHAPE_LABELS.get(shape_type, shape_type.capitalize())
+    if shape_type == "circle" or abs(major - minor) <= 0.2:
+        return f"{label} Ø {major:.1f} mm"
+    return f"{label} {major:.1f} × {minor:.1f} mm"
+
+
+def _classify_shape_component(
+    shape_type: str, major: float, minor: float
+) -> Tuple[Optional[str], Optional[str]]:
+    """Heuristically assign a component type and description to a shape."""
+
+    minor_safe = minor if minor > 0 else 1.0
+    aspect_ratio = major / minor_safe if minor_safe else 0.0
+    component: Optional[str] = None
+    description: Optional[str] = None
+
+    if shape_type == "rectangle":
+        if aspect_ratio >= 6 and minor <= 200:
+            component = "rohr"
+            description = f"{COMPONENT_LABELS[component]} {major:.1f} × {minor:.1f} mm"
+        elif aspect_ratio >= 2 or minor <= 12:
+            component = "blech"
+            description = f"{COMPONENT_LABELS[component]} {major:.1f} × {minor:.1f} mm"
+        elif major <= 150 and minor <= 150:
+            component = "blech"
+            description = f"{COMPONENT_LABELS[component]} {major:.1f} × {minor:.1f} mm"
+    elif shape_type == "curve":
+        component = "rohrbogen"
+        description = f"{COMPONENT_LABELS[component]} {major:.1f} × {minor:.1f} mm"
+    elif shape_type == "circle":
+        if major <= 60:
+            component = "rohrende"
+        else:
+            component = "flansch"
+        description = f"{COMPONENT_LABELS[component]} Ø {major:.1f} mm"
+
+    return component, description
+
+
+def _allocate_position(used_positions: Set[str], start_index: int) -> Tuple[str, int]:
+    index = max(start_index, 1)
+    while str(index) in used_positions:
+        index += 1
+    position = str(index)
+    used_positions.add(position)
+    return position, index + 1
+
+
+def _infer_detected_columns(items: Iterable[BOMItem]) -> List[str]:
+    columns: List[str] = []
+    for item in items:
+        for field_name in ("position", "part_number", "description", "quantity", "unit", "material", "comment"):
+            value = getattr(item, field_name)
+            if value is not None and value != "":
+                columns.append(field_name)
+    return sorted(dict.fromkeys(columns))

--- a/bom_extractor/learning.py
+++ b/bom_extractor/learning.py
@@ -1,0 +1,345 @@
+"""Adaptive confidence estimation and feedback handling for BOM extraction."""
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import Lock
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from typing import Protocol
+
+
+DEFAULT_STORAGE_ENV = "BOM_EXTRACTOR_LEARNING_PATH"
+DEFAULT_STORAGE_FILENAME = "learning_state.json"
+BIAS_PRIOR_POSITIVE = 5.0
+BIAS_PRIOR_NEGATIVE = 3.0
+FEATURE_PRIOR_DEFAULT = (1.0, 1.0)
+MAX_SUMMARY_FEATURES = 6
+
+
+class SupportsFeatures(Protocol):
+    """Protocol describing the subset of :class:`BOMItem` we use."""
+
+    extras: MutableMapping[str, str]
+
+    def __getattr__(self, name: str) -> object:  # pragma: no cover - protocol helper
+        ...
+
+
+@dataclass
+class LearningState:
+    """Serializable container with accumulated feedback statistics."""
+
+    feature_stats: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    total_positive: float = 0.0
+    total_negative: float = 0.0
+    version: int = 1
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "feature_stats": self.feature_stats,
+            "total_positive": self.total_positive,
+            "total_negative": self.total_negative,
+            "version": self.version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "LearningState":
+        feature_stats = {
+            str(name): {
+                "positive": float(values.get("positive", 0.0)),
+                "negative": float(values.get("negative", 0.0)),
+            }
+            for name, values in (data.get("feature_stats") or {}).items()
+        }
+        return cls(
+            feature_stats=feature_stats,
+            total_positive=float(data.get("total_positive", 0.0)),
+            total_negative=float(data.get("total_negative", 0.0)),
+            version=int(data.get("version", 1)),
+        )
+
+
+_FEATURE_PRIORS: Dict[str, tuple[float, float]] = {
+    "source::table": (6.0, 1.0),
+    "source::text": (3.5, 2.0),
+    "source::geometry": (2.5, 3.0),
+    "source::fallback": (1.0, 4.0),
+    "mode::table": (5.0, 1.5),
+    "mode::interpreted": (2.5, 3.0),
+    "heuristic::hoch": (5.5, 1.0),
+    "heuristic::mittel": (3.0, 2.0),
+    "heuristic::niedrig": (1.2, 3.5),
+    "fields::1": (1.0, 2.5),
+    "fields::2": (1.5, 2.0),
+    "fields::3": (2.5, 1.5),
+    "fields::4": (3.0, 1.2),
+    "fields::5+": (3.5, 1.0),
+    "has_quantity": (3.5, 1.0),
+    "has_part_number": (3.0, 1.2),
+    "has_material": (2.6, 1.4),
+}
+
+
+_FEATURE_LABELS: Dict[str, Dict[str, str]] = {
+    "source": {
+        "table": "Tabellenextraktion",
+        "text": "Textinterpretation",
+        "geometry": "Geometrie-Analyse",
+        "fallback": "Fallback-Sammlung",
+    },
+    "mode": {
+        "table": "Dokument enthielt Tabelle",
+        "interpreted": "KI-Interpretation der Zeichnung",
+    },
+    "heuristic": {
+        "hoch": "Heuristische Bewertung: hoch",
+        "mittel": "Heuristische Bewertung: mittel",
+        "niedrig": "Heuristische Bewertung: niedrig",
+    },
+    "fields": {
+        "1": "1 Feld erkannt",
+        "2": "2 Felder erkannt",
+        "3": "3 Felder erkannt",
+        "4": "4 Felder erkannt",
+        "5+": "≥5 Felder erkannt",
+    },
+    "component": {
+        "rohr": "Komponente: Rohr",
+        "rohrbogen": "Komponente: Rohrbogen",
+        "rohrende": "Komponente: Rohrende",
+        "blech": "Komponente: Blech",
+        "flansch": "Komponente: Flansch",
+    },
+}
+
+
+class LearningEngine:
+    """Small online learner that adapts confidence scores via user feedback."""
+
+    def __init__(self, storage_path: Optional[Path] = None) -> None:
+        self._storage_path = storage_path or self._default_storage_path()
+        self._lock = Lock()
+        self._state = self._load_state()
+
+    # ------------------------------------------------------------------
+    # public API
+    def annotate_result(self, result: "BOMExtractionResult") -> "BOMExtractionResult":
+        """Attach confidence scores and learning metadata to an extraction result."""
+
+        context: Dict[str, str] = {}
+        if result.metadata:
+            mode = result.metadata.get("mode")
+            if isinstance(mode, str):
+                context["mode"] = mode
+
+        for item in result.items:
+            features = self._item_features(item, context)
+            confidence = self._score_from_features(features)
+            item.confidence = round(confidence, 4)
+            source = item.extras.get("source")
+            if not source and context.get("mode"):
+                item.extras["source"] = context["mode"]
+            item.extras.setdefault("confidence_estimate", f"{confidence * 100:.1f} %")
+
+        summary = self.summary()
+        if summary:
+            result.metadata = dict(result.metadata)
+            result.metadata["learning_feedback"] = summary.get("total_feedback", 0)
+            result.metadata["learning_success_rate"] = round(
+                float(summary.get("success_rate", 0.0)) * 100.0, 1
+            )
+
+        return result
+
+    def record_feedback(
+        self,
+        ratings: Sequence[tuple[SupportsFeatures, bool]],
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> Dict[str, object]:
+        """Update the learner with user-labelled ratings."""
+
+        if not ratings:
+            return self.summary()
+
+        context: Dict[str, str] = {}
+        if metadata and isinstance(metadata, Mapping):
+            mode = metadata.get("mode")
+            if isinstance(mode, str):
+                context["mode"] = mode
+
+        with self._lock:
+            for item, correct in ratings:
+                features = self._item_features(item, context)
+                self._update_stats(features, correct)
+            self._save_state()
+        return self.summary()
+
+    def summary(self) -> Dict[str, object]:
+        """Return an aggregate summary of the learnt state."""
+
+        total = self._state.total_positive + self._state.total_negative
+        if total <= 0:
+            return {
+                "total_feedback": 0,
+                "success_rate": 0.0,
+                "top_features": [],
+            }
+
+        success_rate = self._state.total_positive / total
+
+        features: List[Dict[str, object]] = []
+        for name, stats in self._state.feature_stats.items():
+            support = stats.get("positive", 0.0) + stats.get("negative", 0.0)
+            if support <= 0:
+                continue
+            label = self._describe_feature(name)
+            feature_success = stats.get("positive", 0.0) / support
+            features.append(
+                {
+                    "feature": name,
+                    "label": label,
+                    "support": int(round(support)),
+                    "success_rate": feature_success,
+                }
+            )
+
+        features.sort(key=lambda entry: (entry["support"], entry["success_rate"]), reverse=True)
+        return {
+            "total_feedback": int(round(total)),
+            "success_rate": success_rate,
+            "top_features": features[:MAX_SUMMARY_FEATURES],
+        }
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _default_storage_path(self) -> Path:
+        env_path = os.environ.get(DEFAULT_STORAGE_ENV)
+        if env_path:
+            path = Path(env_path)
+        else:
+            path = Path(__file__).resolve().parent / DEFAULT_STORAGE_FILENAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _load_state(self) -> LearningState:
+        if self._storage_path.exists():
+            try:
+                with self._storage_path.open("r", encoding="utf-8") as handle:
+                    data = json.load(handle)
+                return LearningState.from_dict(data)
+            except (OSError, ValueError, TypeError):  # pragma: no cover - defensive
+                pass
+        return LearningState()
+
+    def _save_state(self) -> None:
+        try:
+            with self._storage_path.open("w", encoding="utf-8") as handle:
+                json.dump(self._state.to_dict(), handle, ensure_ascii=False, indent=2)
+        except OSError:  # pragma: no cover - defensive
+            pass
+
+    def _item_features(self, item: SupportsFeatures, context: Mapping[str, str]) -> List[str]:
+        features: List[str] = []
+        extras = getattr(item, "extras", {}) or {}
+        source = extras.get("source")
+        if isinstance(source, str):
+            features.append(f"source::{source.lower()}")
+        mode = context.get("mode")
+        if mode:
+            features.append(f"mode::{mode.lower()}")
+
+        confidence_label = extras.get("confidence")
+        if isinstance(confidence_label, str) and confidence_label:
+            features.append(f"heuristic::{confidence_label.strip().lower()}")
+
+        component_code = extras.get("component_code")
+        if isinstance(component_code, str) and component_code:
+            features.append(f"component::{component_code.lower()}")
+
+        field_names = ("position", "part_number", "description", "quantity", "unit", "material", "comment")
+        field_count = 0
+        for name in field_names:
+            value = getattr(item, name, None)
+            if value is not None and value != "":
+                field_count += 1
+        if field_count >= 5:
+            features.append("fields::5+")
+        else:
+            features.append(f"fields::{field_count}")
+
+        if getattr(item, "quantity", None) is not None:
+            features.append("has_quantity")
+        if getattr(item, "part_number", None):
+            features.append("has_part_number")
+        if getattr(item, "material", None):
+            features.append("has_material")
+
+        return features
+
+    def _score_from_features(self, features: Iterable[str]) -> float:
+        logit = math.log(
+            (self._state.total_positive + BIAS_PRIOR_POSITIVE)
+            / (self._state.total_negative + BIAS_PRIOR_NEGATIVE)
+        )
+        for name in features:
+            stats = self._state.feature_stats.get(name)
+            positive = stats.get("positive", 0.0) if stats else 0.0
+            negative = stats.get("negative", 0.0) if stats else 0.0
+            prior_pos, prior_neg = _FEATURE_PRIORS.get(name, FEATURE_PRIOR_DEFAULT)
+            logit += math.log((positive + prior_pos) / (negative + prior_neg))
+        return 1.0 / (1.0 + math.exp(-logit))
+
+    def _update_stats(self, features: Iterable[str], correct: bool) -> None:
+        if correct:
+            self._state.total_positive += 1.0
+        else:
+            self._state.total_negative += 1.0
+        for name in features:
+            stats = self._state.feature_stats.setdefault(name, {"positive": 0.0, "negative": 0.0})
+            key = "positive" if correct else "negative"
+            stats[key] += 1.0
+
+    def _describe_feature(self, name: str) -> str:
+        if "::" not in name:
+            return name
+        prefix, value = name.split("::", 1)
+        value = value.strip()
+        if prefix in _FEATURE_LABELS:
+            return _FEATURE_LABELS[prefix].get(value, f"{prefix}: {value}")
+        if prefix == "has_quantity":
+            return "Menge erkannt"
+        if prefix == "has_part_number":
+            return "Artikelnummer erkannt"
+        if prefix == "has_material":
+            return "Materialangabe vorhanden"
+        return f"{prefix}: {value}"
+
+
+_DEFAULT_ENGINE: Optional[LearningEngine] = None
+
+
+def get_learning_engine() -> LearningEngine:
+    """Return a process-wide singleton :class:`LearningEngine`."""
+
+    global _DEFAULT_ENGINE
+    if _DEFAULT_ENGINE is None:
+        _DEFAULT_ENGINE = LearningEngine()
+    return _DEFAULT_ENGINE
+
+
+def apply_learning_to_result(result: "BOMExtractionResult") -> "BOMExtractionResult":
+    """Convenience wrapper to attach learning metadata using the default engine."""
+
+    engine = get_learning_engine()
+    return engine.annotate_result(result)
+
+
+__all__ = [
+    "LearningEngine",
+    "apply_learning_to_result",
+    "get_learning_engine",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi>=0.103,<0.104
+uvicorn[standard]>=0.23,<0.24
+pdfplumber>=0.10,<0.11
+python-multipart>=0.0.6,<0.0.7
+pydantic>=1.10,<2.0
+reportlab>=3.6,<3.7
+pytest>=7.4,<8.0
+httpx>=0.24,<0.25

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,12 @@
+"""Test suite package initialiser to configure shared settings."""
+
+from pathlib import Path
+import os
+
+TEST_LEARNING_STATE = Path(__file__).parent / "test_learning_state.json"
+os.environ.setdefault("BOM_EXTRACTOR_LEARNING_PATH", str(TEST_LEARNING_STATE))
+try:
+    if TEST_LEARNING_STATE.exists():
+        TEST_LEARNING_STATE.unlink()
+except OSError:
+    pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from .utils import build_pdf_table, build_pdf_text
+
+
+client = TestClient(app)
+
+
+def test_extract_endpoint(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "bom.pdf"
+    data = [
+        ["Item", "Qty", "Description"],
+        ["1", "5", "Washer"],
+        ["2", "3", "Screw"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    with pdf_path.open("rb") as pdf_file:
+        response = client.post(
+            "/extract", files={"file": (pdf_path.name, pdf_file, "application/pdf")}
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"][0]["description"] == "Washer"
+    assert payload["items"][0]["quantity"] == 5
+    assert "confidence" in payload["items"][0]
+    assert payload["items"][0]["confidence"] is not None
+    assert payload["metadata"]["source"] == "bom.pdf"
+
+
+def test_extract_endpoint_interprets_annotations(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "callouts.pdf"
+    build_pdf_text(
+        pdf_path,
+        [
+            "Pos 1 Schraube M8 Qty 4",
+            "Pos 2 Mutter M8 (2x)",
+        ],
+    )
+
+    with pdf_path.open("rb") as pdf_file:
+        response = client.post(
+            "/extract", files={"file": (pdf_path.name, pdf_file, "application/pdf")}
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["metadata"]["mode"] == "interpreted"
+    assert payload["metadata"]["annotation_items"] == 2
+    assert payload["items"][0]["quantity"] == 4
+    assert payload["items"][0]["description"]
+
+
+def test_web_interface_served() -> None:
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    assert "Stücklisten-Extractor" in response.text
+    assert "upload-form" in response.text
+
+
+def test_feedback_endpoint(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "feedback.pdf"
+    data = [
+        ["Item", "Qty", "Description"],
+        ["1", "2", "Bracket"],
+        ["2", "4", "Bolt"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    with pdf_path.open("rb") as pdf_file:
+        extract_response = client.post(
+            "/extract", files={"file": (pdf_path.name, pdf_file, "application/pdf")}
+        )
+
+    assert extract_response.status_code == 200
+    payload = extract_response.json()
+    ratings = [{"item": item, "correct": True} for item in payload["items"]]
+
+    feedback_response = client.post(
+        "/feedback",
+        json={
+            "document": payload["metadata"].get("source"),
+            "ratings": ratings,
+            "metadata": payload["metadata"],
+        },
+    )
+
+    assert feedback_response.status_code == 200
+    summary = feedback_response.json()["summary"]
+    assert summary["total_feedback"] >= len(ratings)
+
+    summary_response = client.get("/feedback/summary")
+    assert summary_response.status_code == 200
+    summary_payload = summary_response.json()
+    assert summary_payload["total_feedback"] >= len(ratings)

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from bom_extractor import BOMExtractionResult, BOMItem, LearningEngine, extract_bom_from_pdf
+from .utils import build_pdf_drawing, build_pdf_table, build_pdf_text
+
+
+def test_extract_basic_table(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "drawing.pdf"
+    data = [
+        ["Item", "Qty", "Description", "Material"],
+        ["1", "4", "Bolt M8", "Steel"],
+        ["2", "2", "Nut M8", "Steel"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    result = extract_bom_from_pdf(str(pdf_path))
+
+    assert result.detected_columns == ["description", "material", "position", "quantity"]
+    assert len(result.items) == 2
+    first = result.items[0]
+    assert first.position == "1"
+    assert first.description == "Bolt M8"
+    assert first.material == "Steel"
+    assert first.quantity == 4
+    assert first.confidence is not None
+    assert 0.0 <= first.confidence <= 1.0
+    assert "learning_feedback" in result.metadata
+
+
+def test_extract_german_headers(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "zeichnung.pdf"
+    data = [
+        ["Pos.", "Benennung", "Menge", "Einheit"],
+        ["10", "Schraube M10", "12 Stk", "Stk"],
+        ["20", "Mutter M10", "8", "Stk"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    result = extract_bom_from_pdf(str(pdf_path))
+
+    assert len(result.items) == 2
+    first = result.items[0]
+    assert first.position == "10"
+    assert first.quantity == 12
+    assert first.unit == "Stk"
+
+
+def test_extract_interprets_text_annotations(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "text.pdf"
+    build_pdf_text(
+        pdf_path,
+        [
+            "Pos 1 Schraube M8 Qty 4",
+            "Pos 2 Mutter M8 (2x)",
+            "3 Lager 6205 qty 2",
+        ],
+    )
+
+    result = extract_bom_from_pdf(str(pdf_path))
+
+    assert result.metadata["mode"] == "interpreted"
+    assert result.metadata["annotation_items"] == 3
+    assert len(result.items) >= 3
+    first = result.items[0]
+    assert first.position == "1"
+    assert first.quantity == 4
+    assert first.description and "Schraube" in first.description
+    assert "quantity" in result.detected_columns
+    assert all(item.confidence is not None for item in result.items)
+
+
+def test_extract_interprets_geometry(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "shapes.pdf"
+    build_pdf_drawing(pdf_path)
+
+    result = extract_bom_from_pdf(str(pdf_path))
+
+    assert result.metadata["mode"] == "interpreted"
+    assert result.metadata["geometry_items"] >= 1
+    assert result.metadata["annotation_items"] == 0
+    assert any(item.extras.get("component_type") == "Blech" for item in result.items)
+    assert all(item.quantity and item.quantity >= 1 for item in result.items)
+    component_types = {
+        item.extras.get("component_type")
+        for item in result.items
+        if item.extras.get("source") == "geometry" and item.extras.get("component_type")
+    }
+    assert {"Blech", "Rohr", "Flansch"} <= component_types
+    assert all(item.confidence is not None for item in result.items)
+
+
+def test_component_keywords_in_table(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "components_table.pdf"
+    data = [
+        ["Pos", "Benennung", "Menge"],
+        ["1", "Rohr DN50", "3"],
+        ["2", "Rohrbogen 90°", "2"],
+        ["3", "Blech 5 mm", "1"],
+        ["4", "Flansch PN16", "6"],
+        ["5", "Rohrende Kappe", "2"],
+    ]
+    build_pdf_table(pdf_path, data)
+
+    result = extract_bom_from_pdf(str(pdf_path))
+
+    components = {
+        item.extras.get("component_type") for item in result.items if item.extras.get("component_type")
+    }
+    assert {"Rohr", "Rohrbogen", "Blech", "Flansch", "Rohrende"} <= components
+    classified_items = [item for item in result.items if item.extras.get("component_type")]
+    assert all(item.extras.get("component_source") == "text" for item in classified_items)
+
+
+def test_component_keywords_in_text(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "components_text.pdf"
+    build_pdf_text(
+        pdf_path,
+        [
+            "1 Rohr DN80 qty 2",
+            "2 Rohrbogen 90° qty 3",
+            "3 Flansch PN16 qty 4",
+            "4 Blech 8mm qty 1",
+            "5 Rohrende Endkappe qty 2",
+        ],
+    )
+
+    result = extract_bom_from_pdf(str(pdf_path))
+
+    components = {
+        item.extras.get("component_type") for item in result.items if item.extras.get("component_type")
+    }
+    assert {"Rohr", "Rohrbogen", "Blech", "Flansch", "Rohrende"} <= components
+    classified_items = [item for item in result.items if item.extras.get("component_type")]
+    assert all(item.extras.get("component_source") == "text" for item in classified_items)
+
+
+def test_learning_feedback_updates_confidence(tmp_path: Path) -> None:
+    engine = LearningEngine(storage_path=tmp_path / "state.json")
+    base_item = BOMItem(description="Rohr DN50", quantity=2, extras={"source": "text", "component_code": "rohr"})
+    before_result = BOMExtractionResult(
+        items=[
+            BOMItem(
+                **{
+                    **base_item.__dict__,
+                    "extras": dict(base_item.extras),
+                }
+            )
+        ],
+        detected_columns=[],
+        metadata={"mode": "interpreted"},
+    )
+    engine.annotate_result(before_result)
+    before_confidence = before_result.items[0].confidence or 0.0
+
+    engine.record_feedback([(base_item, True)], metadata={"mode": "interpreted"})
+
+    after_item = BOMItem(description="Rohr DN50", quantity=2, extras={"source": "text", "component_code": "rohr"})
+    after_result = BOMExtractionResult(
+        items=[after_item],
+        detected_columns=[],
+        metadata={"mode": "interpreted"},
+    )
+    engine.annotate_result(after_result)
+    after_confidence = after_result.items[0].confidence or 0.0
+
+    assert after_confidence >= before_confidence
+    summary = engine.summary()
+    assert summary["total_feedback"] >= 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,72 @@
+"""Utilities shared by the test-suite."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+
+
+def build_pdf_table(path: Path, data: Sequence[Sequence[str]]) -> Path:
+    """Create a simple PDF file containing a table."""
+
+    doc = SimpleDocTemplate(str(path), pagesize=A4)
+    table = Table(data, repeatRows=1)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.black),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+            ]
+        )
+    )
+    doc.build([table])
+    return path
+
+
+def build_pdf_text(path: Path, lines: Iterable[str]) -> Path:
+    """Create a PDF that only contains free text (used for negative tests)."""
+
+    from reportlab.pdfgen import canvas
+
+    c = canvas.Canvas(str(path), pagesize=A4)
+    text_object = c.beginText(40, A4[1] - 50)
+    for line in lines:
+        text_object.textLine(line)
+    c.drawText(text_object)
+    c.showPage()
+    c.save()
+    return path
+
+
+def build_pdf_drawing(path: Path) -> Path:
+    """Create a minimalist drawing with geometric primitives for interpretation tests."""
+
+    from reportlab.pdfgen import canvas
+
+    c = canvas.Canvas(str(path), pagesize=A4)
+    rectangles = [
+        (40, A4[1] - 120, 80, 40),
+        (160, A4[1] - 120, 80, 40),
+        (40, A4[1] - 200, 80, 40),
+        (320, A4[1] - 160, 200, 20),
+        (220, A4[1] - 220, 60, 60),
+    ]
+    for x, y, width, height in rectangles:
+        c.rect(x, y, width, height, stroke=1, fill=0)
+
+    circles = [
+        (360, A4[1] - 260, 25),
+        (420, A4[1] - 260, 25),
+        (180, A4[1] - 320, 90),
+    ]
+    for x, y, radius in circles:
+        c.circle(x, y, radius, stroke=1, fill=0)
+
+    c.showPage()
+    c.save()
+    return path


### PR DESCRIPTION
## Summary
- add an online learning engine that scores BOM items, persists feedback-driven feature statistics, and annotates extraction results with adaptive confidence values
- expose feedback submission and summary endpoints, extend the API schema, and surface the learning metadata through the FastAPI service
- embed an evaluation panel in the web UI so users can rate each item, submit feedback, and view aggregated learning progress, plus extend tests to cover the new flow

## Testing
- `python -m compileall bom_extractor tests app`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cfd7f8e2f0832c8c69c147cf0f8b23